### PR TITLE
If S3 Inventory is enabled, configure the metastore docker img to create hive tables on the data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.1.0] - 2020-03-18
+### Added
+- If S3 inventory is enabled, Hive tables will be created for each Apiary schema bucket.  They will be updated on a scheduled basis each day, etc.
+- Note that the scheduled job is currently only implemented for Kubernetes deployments of Apiary.
+- Variable to configure S3 inventory table update schedule - `s3_inventory_update_schedule`.
+
 ## [5.0.0] - 2020-03-16
 ### Added
 - Variable to configure `apiary_assume_roles` cross-region S3 access.

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -65,6 +65,7 @@
 | s3_block_public_access | Variable to enable S3 Block Public Access. | bool | `false` | no |
 | s3_enable_inventory | Enable S3 inventory configuration. | bool | `false` | no |
 | s3_inventory_format | Output format for S3 inventory results. Can be Parquet, ORC, CSV | string | `ORC` | no |
+| s3_inventory_update_schedule | Cron schedule to update S3 inventory tables (if enabled). Defaults to every 12 hours. | string | `0 */12 * * *` | no |
 | s3_lifecycle_policy_transition_period | Number of days for transition to a different storage class using lifecycle policy. | string  | `30` | no |
 | s3_storage_class | Destination S3 storage class for transition in the lifecycle policy. | string  | `INTELLIGENT_TIERING` | no |
 | secondary_vpcs | List of VPCs to associate with Service Discovery namespace. | list | `<list>` | no |

--- a/common.tf
+++ b/common.tf
@@ -16,6 +16,9 @@ locals {
   assume_allowed_principals            = split(",", join(",", [for role in var.apiary_assume_roles : join(",", [for principal in role.principals : replace(principal, "/:role.*/", ":root")])]))
   producer_allowed_principals          = split(",", join(",", values(var.apiary_producer_iamroles)))
   final_atlas_cluster_name             = "${var.atlas_cluster_name == "" ? local.instance_alias : var.atlas_cluster_name}"
+  s3_inventory_prefix                  = "EntireBucketDaily"
+  s3_inventory_bucket                  = var.s3_enable_inventory ? "${local.apiary_bucket_prefix}-s3-inventory" : ""
+  apiary_iam_buckets                   = compact(concat(local.apiary_data_buckets, [local.s3_inventory_bucket]))
 }
 
 data "aws_iam_account_alias" "current" {}

--- a/common.tf
+++ b/common.tf
@@ -19,7 +19,6 @@ locals {
   final_atlas_cluster_name             = "${var.atlas_cluster_name == "" ? local.instance_alias : var.atlas_cluster_name}"
   s3_inventory_prefix                  = "EntireBucketDaily"
   s3_inventory_bucket                  = var.s3_enable_inventory ? "${local.apiary_bucket_prefix}-s3-inventory" : ""
-  apiary_iam_buckets                   = compact(concat(local.apiary_data_buckets, [local.s3_inventory_bucket]))
 }
 
 data "aws_iam_account_alias" "current" {}

--- a/iam-policy-s3-buckets.tf
+++ b/iam-policy-s3-buckets.tf
@@ -30,8 +30,8 @@ resource "aws_iam_role_policy" "s3_data_for_hms_readwrite" {
                               "s3:PutObjectVersionTagging"
                             ],
                   "Resource": [
-                                "${join("\",\"", formatlist("arn:aws:s3:::%s", local.apiary_iam_buckets))}",
-                                "${join("\",\"", formatlist("arn:aws:s3:::%s/*", local.apiary_iam_buckets))}"
+                                "${join("\",\"", formatlist("arn:aws:s3:::%s", local.apiary_data_buckets))}",
+                                "${join("\",\"", formatlist("arn:aws:s3:::%s/*", local.apiary_data_buckets))}"
                               ]
                 }
               ]
@@ -55,8 +55,8 @@ resource "aws_iam_role_policy" "s3_data_for_hms_readonly" {
                               "s3:List*"
                             ],
                   "Resource": [
-                                "${join("\",\"", formatlist("arn:aws:s3:::%s", local.apiary_iam_buckets))}",
-                                "${join("\",\"", formatlist("arn:aws:s3:::%s/*", local.apiary_iam_buckets))}"
+                                "${join("\",\"", formatlist("arn:aws:s3:::%s", local.apiary_data_buckets))}",
+                                "${join("\",\"", formatlist("arn:aws:s3:::%s/*", local.apiary_data_buckets))}"
                               ]
                 }
               ]
@@ -117,6 +117,56 @@ resource "aws_iam_role_policy" "external_s3_data_for_hms_readonly" {
                   "Resource": [
                                 "${join("\",\"", formatlist("arn:aws:s3:::%s", var.external_data_buckets))}",
                                 "${join("\",\"", formatlist("arn:aws:s3:::%s/*", var.external_data_buckets))}"
+                              ]
+                }
+              ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "s3_inventory_for_hms_readwrite" {
+  count = var.s3_enable_inventory ? 1 : 0
+  name  = "s3-inventory"
+  role  = "${aws_iam_role.apiary_hms_readwrite.id}"
+
+  policy = <<EOF
+{
+ "Version": "2012-10-17",
+ "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                              "s3:Get*",
+                              "s3:List*"
+                            ],
+                  "Resource": [
+                                "${format("arn:aws:s3:::%s", local.s3_inventory_bucket)}",
+                                "${format("arn:aws:s3:::%s/*", local.s3_inventory_bucket)}"
+                              ]
+                }
+              ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "s3_inventory_for_hms_readonly" {
+  count = var.s3_enable_inventory ? 1 : 0
+  name  = "s3-inventory"
+  role  = "${aws_iam_role.apiary_hms_readonly.id}"
+
+  policy = <<EOF
+{
+ "Version": "2012-10-17",
+ "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                              "s3:Get*",
+                              "s3:List*"
+                            ],
+                  "Resource": [
+                                "${format("arn:aws:s3:::%s", local.s3_inventory_bucket)}",
+                                "${format("arn:aws:s3:::%s/*", local.s3_inventory_bucket)}"
                               ]
                 }
               ]

--- a/iam-policy-s3-buckets.tf
+++ b/iam-policy-s3-buckets.tf
@@ -30,8 +30,8 @@ resource "aws_iam_role_policy" "s3_data_for_hms_readwrite" {
                               "s3:PutObjectVersionTagging"
                             ],
                   "Resource": [
-                                "${join("\",\"", formatlist("arn:aws:s3:::%s", local.apiary_data_buckets))}",
-                                "${join("\",\"", formatlist("arn:aws:s3:::%s/*", local.apiary_data_buckets))}"
+                                "${join("\",\"", formatlist("arn:aws:s3:::%s", local.apiary_iam_buckets))}",
+                                "${join("\",\"", formatlist("arn:aws:s3:::%s/*", local.apiary_iam_buckets))}"
                               ]
                 }
               ]
@@ -55,8 +55,8 @@ resource "aws_iam_role_policy" "s3_data_for_hms_readonly" {
                               "s3:List*"
                             ],
                   "Resource": [
-                                "${join("\",\"", formatlist("arn:aws:s3:::%s", local.apiary_data_buckets))}",
-                                "${join("\",\"", formatlist("arn:aws:s3:::%s/*", local.apiary_data_buckets))}"
+                                "${join("\",\"", formatlist("arn:aws:s3:::%s", local.apiary_iam_buckets))}",
+                                "${join("\",\"", formatlist("arn:aws:s3:::%s/*", local.apiary_iam_buckets))}"
                               ]
                 }
               ]

--- a/k8s-cronjobs.tf
+++ b/k8s-cronjobs.tf
@@ -29,7 +29,7 @@ resource "kubernetes_cron_job" "apiary_inventory_repair" {
               name = "s3-inventory-repair"
             }
             annotations = {
-              "iam.amazonaws.com/role" = aws_iam_role.apiary_hms_readwrite.name
+              "iam.amazonaws.com/role" = aws_iam_role.apiary_hms_readonly.name
             }
           }
 

--- a/k8s-cronjobs.tf
+++ b/k8s-cronjobs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2020 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  */
@@ -18,8 +18,7 @@ resource "kubernetes_cron_job" "apiary_inventory_repair" {
   spec {
     concurrency_policy = "Replace"
     failed_jobs_history_limit = 5
-    #TODO: Make me once a day after testing
-    schedule = "*/10 * * * *"
+    schedule = var.s3_inventory_update_schedule
 
     job_template {
       metadata {}

--- a/k8s-cronjobs.tf
+++ b/k8s-cronjobs.tf
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2018-2019 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+resource "kubernetes_cron_job" "apiary_inventory_repair" {
+  count = (var.s3_enable_inventory && var.hms_instance_type == "k8s") ? 1 : 0
+  metadata {
+    name      = "s3-inventory-repair"
+    namespace = "metastore"
+
+    labels = {
+      name = "s3-inventory-repair"
+    }
+  }
+
+  spec {
+    concurrency_policy = "Replace"
+    failed_jobs_history_limit = 5
+    #TODO: Make me once a day after testing
+    schedule = "*/10 * * * *"
+
+    job_template {
+      metadata {}
+      spec {
+        template {
+          metadata {
+            labels = {
+              name = "s3-inventory-repair"
+            }
+            annotations = {
+              "iam.amazonaws.com/role" = aws_iam_role.apiary_hms_readwrite.name
+            }
+          }
+
+          spec {
+            container {
+              image   = "${var.hms_docker_image}:${var.hms_docker_version}"
+              name    = "s3-inventory-repair"
+              command = [ "/s3_inventory_repair.sh" ]
+              env {
+                name = "AWS_REGION"
+                value = var.aws_region
+              }
+              env {
+                name = "AWS_DEFAULT_REGION"
+                value = var.aws_region
+              }
+              env {
+                name = "HIVE_DB_NAMES"
+                value = join(",", local.apiary_managed_schema_names_original)
+              }
+              env {
+                name = "INSTANCE_NAME"
+                value = local.instance_alias
+              }
+              env {
+                name = "HIVE_METASTORE_LOG_LEVEL"
+                value = var.hms_log_level
+              }
+              env {
+                name = "ENABLE_S3_INVENTORY"
+                value = var.s3_enable_inventory
+              }
+              env {
+                name = "APIARY_S3_INVENTORY_TABLE_FORMAT"
+                value = var.s3_inventory_format
+              }
+              env {
+                name = "APIARY_S3_INVENTORY_PREFIX"
+                value = local.s3_inventory_prefix
+              }
+            }
+            image_pull_secrets {
+              name = var.k8s_docker_registry_secret
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/k8s-readwrite.tf
+++ b/k8s-readwrite.tf
@@ -147,14 +147,6 @@ resource "kubernetes_deployment" "apiary_hms_readwrite" {
             name  = "ENABLE_S3_INVENTORY"
             value = var.s3_enable_inventory
           }
-          env {
-            name  = "APIARY_S3_INVENTORY_TABLE_FORMAT"
-            value = var.s3_inventory_format
-          }
-          env {
-            name  = "APIARY_S3_INVENTORY_PREFIX"
-            value = local.s3_inventory_prefix
-          }
 
           resources {
             limits {

--- a/k8s-readwrite.tf
+++ b/k8s-readwrite.tf
@@ -143,6 +143,18 @@ resource "kubernetes_deployment" "apiary_hms_readwrite" {
             name  = "KAFKA_TOPIC_NAME"
             value = var.kafka_topic_name
           }
+          env {
+            name  = "ENABLE_S3_INVENTORY"
+            value = var.s3_enable_inventory
+          }
+          env {
+            name  = "APIARY_S3_INVENTORY_TABLE_FORMAT"
+            value = var.s3_inventory_format
+          }
+          env {
+            name  = "APIARY_S3_INVENTORY_PREFIX"
+            value = local.s3_inventory_prefix
+          }
 
           resources {
             limits {

--- a/s3.tf
+++ b/s3.tf
@@ -6,9 +6,10 @@
 
 resource "aws_s3_bucket" "apiary_inventory_bucket" {
   count  = var.s3_enable_inventory == true ? 1 : 0
-  bucket = "${local.apiary_bucket_prefix}-s3-inventory"
+  bucket = local.s3_inventory_bucket
   acl    = "private"
-  tags   = "${merge(map("Name", "${local.apiary_bucket_prefix}-s3-inventory"), "${var.apiary_tags}")}"
+  #tags   = "${merge(map("Name", ${local.s3_inventory_bucket}, "${var.apiary_tags}"))}"
+  tags   = "${merge(map("Name", "${local.s3_inventory_bucket}"), "${var.apiary_tags}")}"
   policy = <<EOF
 {
   "Version":"2012-10-17",
@@ -18,7 +19,7 @@ resource "aws_s3_bucket" "apiary_inventory_bucket" {
       "Effect":"Allow",
       "Principal": {"Service": "s3.amazonaws.com"},
       "Action":["s3:PutObject"],
-      "Resource":["arn:aws:s3:::${local.apiary_bucket_prefix}-s3-inventory/*"],
+      "Resource":["arn:aws:s3:::${local.s3_inventory_bucket}/*"],
       "Condition": {
           "ArnLike": {
               "aws:SourceArn": "arn:aws:s3:::${local.apiary_bucket_prefix}-*"
@@ -83,7 +84,7 @@ resource "aws_s3_bucket_inventory" "apiary_bucket" {
   count  = var.s3_enable_inventory == true ? "${length(local.apiary_data_buckets)}" : 0
   bucket = "${aws_s3_bucket.apiary_data_bucket.*.id[count.index]}"
 
-  name = "EntireBucketDaily"
+  name = local.s3_inventory_prefix
 
   included_object_versions = "All"
 
@@ -112,6 +113,16 @@ resource "aws_s3_bucket_public_access_block" "apiary_bucket" {
   block_public_policy = true
   ignore_public_acls  = true
 }
+
+resource "aws_s3_bucket_public_access_block" "apiary_inventory_bucket" {
+  count  = var.s3_enable_inventory == true ? 1 : 0
+  bucket = local.s3_inventory_bucket
+
+  block_public_acls   = true
+  block_public_policy = true
+  ignore_public_acls  = true
+}
+
 
 resource "aws_s3_bucket_notification" "data_events" {
   count  = "${var.enable_data_events == "" ? 0 : length(local.apiary_data_buckets)}"

--- a/templates.tf
+++ b/templates.tf
@@ -46,6 +46,11 @@ data "template_file" "hms_readwrite" {
 
     #to instruct ECS to use repositoryCredentials for private docker registry
     docker_auth = "${var.docker_registry_auth_secret_name == "" ? "" : format("\"repositoryCredentials\" :{\n \"credentialsParameter\":\"%s\"\n},", join("", data.aws_secretsmanager_secret.docker_registry.*.arn))}"
+
+    # S3 inventory
+    s3_enable_inventory = var.s3_enable_inventory
+    s3_inventory_bucket = local.s3_inventory_bucket
+    s3_inventory_prefix = local.s3_inventory_prefix
   }
 }
 

--- a/templates.tf
+++ b/templates.tf
@@ -49,8 +49,6 @@ data "template_file" "hms_readwrite" {
 
     # S3 inventory
     s3_enable_inventory = var.s3_enable_inventory
-    s3_inventory_format = var.s3_inventory_format
-    s3_inventory_prefix = local.s3_inventory_prefix
   }
 }
 

--- a/templates.tf
+++ b/templates.tf
@@ -49,7 +49,7 @@ data "template_file" "hms_readwrite" {
 
     # S3 inventory
     s3_enable_inventory = var.s3_enable_inventory
-    s3_inventory_bucket = local.s3_inventory_bucket
+    s3_inventory_format = var.s3_inventory_format
     s3_inventory_prefix = local.s3_inventory_prefix
   }
 }

--- a/templates/apiary-hms-readwrite.json
+++ b/templates/apiary-hms-readwrite.json
@@ -137,6 +137,18 @@
      {
       "name": "KAFKA_TOPIC_NAME",
       "value": "${kafka_topic_name}"
+     },
+     {
+      "name": "ENABLE_S3_INVENTORY",
+      "value": "${s3_enable_inventory}"
+     },
+     {
+      "name": "APIARY_S3_INVENTORY_TABLE_FORMAT",
+      "value": "${s3_inventory_format}"
+     },
+     {
+      "name": "APIARY_S3_INVENTORY_PREFIX",
+      "value": "${s3_inventory_prefix}"
      }
     ]
   }

--- a/templates/apiary-hms-readwrite.json
+++ b/templates/apiary-hms-readwrite.json
@@ -141,14 +141,6 @@
      {
       "name": "ENABLE_S3_INVENTORY",
       "value": "${s3_enable_inventory}"
-     },
-     {
-      "name": "APIARY_S3_INVENTORY_TABLE_FORMAT",
-      "value": "${s3_inventory_format}"
-     },
-     {
-      "name": "APIARY_S3_INVENTORY_PREFIX",
-      "value": "${s3_inventory_prefix}"
      }
     ]
   }

--- a/variables.tf
+++ b/variables.tf
@@ -425,3 +425,9 @@ variable "kafka_topic_name" {
   type        = "string"
   default     = ""
 }
+
+variable "s3_inventory_update_schedule" {
+  description = "Cron schedule to update S3 inventory tables (if enabled). Defaults to every 12 hours."
+  type        = "string"
+  default     = "0 */12 * * *"
+}


### PR DESCRIPTION
Note that currently, the way AWS creates the data with symlink.txt, only Presto and/or Athena can be used to query the tables.