### PR TITLE
[Issue-165] Add init container logic for mysql setup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [6.5.0] - TBD
+## [6.5.0] - 2020-08-31
 ### Changed
 - [Issue 165](https://github.com/ExpediaGroup/apiary-data-lake/issues/165) Use init containers instead of `mysql` commands to initialize mysql users.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.5.0] - TBD
+### Changed
+- [Issue 165](https://github.com/ExpediaGroup/apiary-data-lake/issues/165) Use init containers instead of `mysql` commands to initialize mysql users.
+
+### Removed
+- `mysql` dependency for this terraform module.
+
 ## [6.4.1] - 2020-06-18
 ### Fixed
 - [Issue 162](https://github.com/ExpediaGroup/apiary-data-lake/issues/162) Add explicit dependency for S3 public access block to resolve race condition.

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -51,6 +51,8 @@
 | hms_rw_heapsize | Heapsize for the read/write Hive Metastore. Valid values: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html | string | - | yes |
 | iam_name_root | Name to identify Hive Metastore IAM roles. | string | `hms` | no |
 | ingress_cidr | Generally allowed ingress CIDR list. | list | - | yes |
+| init_container_image | Docker image for running HMS init container. | string | `tbd` | no |
+| init_container_version | Docker image version for running HMS init container. | string | `0.0.1` | no |
 | instance_name | Apiary instance name to identify resources in multi-instance deployments. | string | `` | no |
 | k8s_docker_registry_secret| Docker Registry authentication K8s secret name. | string | `` | no |
 | kiam_arn | Kiam server IAM role ARN. | string | `` | no |

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -52,8 +52,8 @@
 | hms_rw_heapsize | Heapsize for the read/write Hive Metastore. Valid values: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html | string | - | yes |
 | iam_name_root | Name to identify Hive Metastore IAM roles. | string | `hms` | no |
 | ingress_cidr | Generally allowed ingress CIDR list. | list | - | yes |
-| init_container_image | Docker image for running HMS init container. | string | `tbd` | no |
-| init_container_version | Docker image version for running HMS init container. | string | `0.0.1` | no |
+| init_container_image | Docker image for running HMS init container. Required if `external_database_host` is unset. | string | `` | no |
+| init_container_version | Docker image version for running HMS init container. Required if `external_database_host` is unset. | string | `` | no |
 | instance_name | Apiary instance name to identify resources in multi-instance deployments. | string | `` | no |
 | k8s_docker_registry_secret| Docker Registry authentication K8s secret name. | string | `` | no |
 | kiam_arn | Kiam server IAM role ARN. | string | `` | no |

--- a/db.tf
+++ b/db.tf
@@ -99,7 +99,7 @@ resource "random_string" "secret_name_suffix" {
 
 resource "aws_secretsmanager_secret" "apiary_mysql_master_credentials" {
   count                   = "${var.external_database_host == "" ? var.db_instance_count : 0}"
-  name                    = "apiary_db_master_user_${random_string.secret_name_suffix[0].result}"
+  name                    = "${local.instance_alias}_db_master_user_${random_string.secret_name_suffix[0].result}"
   tags                    = var.apiary_tags
   recovery_window_in_days = 0
 }

--- a/db.tf
+++ b/db.tf
@@ -99,14 +99,14 @@ resource "random_string" "secret_name_suffix" {
 
 resource "aws_secretsmanager_secret" "apiary_mysql_master_credentials" {
   count                   = "${var.external_database_host == "" ? var.db_instance_count : 0}"
-  name                    = "apiary_db_master_user_${random_string.secret_name_suffix.result}"
+  name                    = "apiary_db_master_user_${random_string.secret_name_suffix[0].result}"
   tags                    = var.apiary_tags
   recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "apiary_mysql_master_credentials" {
   count         = "${var.external_database_host == "" ? var.db_instance_count : 0}"
-  secret_id     = aws_secretsmanager_secret.apiary_mysql_master_credentials.id
+  secret_id     = aws_secretsmanager_secret.apiary_mysql_master_credentials[0].id
   secret_string = jsonencode(
     map(
       "username", var.db_master_username,

--- a/db.tf
+++ b/db.tf
@@ -89,63 +89,23 @@ resource "aws_rds_cluster_instance" "apiary_cluster_instance" {
   }
 }
 
-resource "null_resource" "db_iam_auth" {
-  count      = "${var.external_database_host == "" ? 1 : 0}"
-  depends_on = [aws_rds_cluster_instance.apiary_cluster_instance]
-
-  provisioner "local-exec" {
-    command = "${path.module}/scripts/db-iam-auth.sh &> /dev/null"
-
-    environment = {
-      MYSQL_HOST            = "${aws_rds_cluster.apiary_cluster[0].endpoint}"
-      MYSQL_MASTER_USER     = "${aws_rds_cluster.apiary_cluster[0].master_username}"
-      MYSQL_MASTER_PASSWORD = "${aws_rds_cluster.apiary_cluster[0].master_password}"
-    }
-  }
+resource "random_string" "secret_seed_slug" {
+  length  = 8
+  special = false
 }
 
-resource "null_resource" "mysql_rw_user" {
-  count      = "${var.external_database_host == "" ? 1 : 0}"
-  depends_on = [aws_rds_cluster_instance.apiary_cluster_instance]
-
-  triggers = {
-    secret_string = "${md5(data.aws_secretsmanager_secret_version.db_rw_user.secret_string)}"
-  }
-
-  provisioner "local-exec" {
-    command = "${path.module}/scripts/mysql-user.sh &> /dev/null"
-
-    environment = {
-      MYSQL_HOST            = "${aws_rds_cluster.apiary_cluster[0].endpoint}"
-      MYSQL_MASTER_USER     = "${aws_rds_cluster.apiary_cluster[0].master_username}"
-      MYSQL_MASTER_PASSWORD = "${aws_rds_cluster.apiary_cluster[0].master_password}"
-      MYSQL_DB              = "${var.apiary_database_name}"
-      MYSQL_SECRET_ARN      = "${data.aws_secretsmanager_secret.db_rw_user.arn}"
-      MYSQL_PERMISSIONS     = "ALL"
-      AWS_REGION            = "${var.aws_region}"
-    }
-  }
+resource "aws_secretsmanager_secret" "apiary_mysql_master_credentials" {
+  name = "apiary_db_master_user_${random_string.secret_seed_slug.result}"
+  tags = var.apiary_tags
+  recovery_window_in_days = 0
 }
 
-resource "null_resource" "mysql_ro_user" {
-  count      = "${var.external_database_host == "" ? 1 : 0}"
-  depends_on = [aws_rds_cluster_instance.apiary_cluster_instance]
-
-  triggers = {
-    secret_string = "${md5(data.aws_secretsmanager_secret_version.db_ro_user.secret_string)}"
-  }
-
-  provisioner "local-exec" {
-    command = "${path.module}/scripts/mysql-user.sh &> /dev/null"
-
-    environment = {
-      MYSQL_HOST            = "${aws_rds_cluster.apiary_cluster[0].endpoint}"
-      MYSQL_MASTER_USER     = "${aws_rds_cluster.apiary_cluster[0].master_username}"
-      MYSQL_MASTER_PASSWORD = "${aws_rds_cluster.apiary_cluster[0].master_password}"
-      MYSQL_DB              = "${var.apiary_database_name}"
-      MYSQL_SECRET_ARN      = "${data.aws_secretsmanager_secret.db_ro_user.arn}"
-      MYSQL_PERMISSIONS     = "SELECT"
-      AWS_REGION            = "${var.aws_region}"
-    }
-  }
+resource "aws_secretsmanager_secret_version" "apiary_mysql_master_credentials" {
+  secret_id     = aws_secretsmanager_secret.apiary_mysql_master_credentials.id
+  secret_string = jsonencode(
+    map(
+      "username", var.db_master_username,
+      "password", random_string.db_master_password[0].result
+    )
+  )
 }

--- a/db.tf
+++ b/db.tf
@@ -90,17 +90,20 @@ resource "aws_rds_cluster_instance" "apiary_cluster_instance" {
 }
 
 resource "random_string" "secret_seed_slug" {
+  count   = "${var.external_database_host == "" ? var.db_instance_count : 0}"
   length  = 8
   special = false
 }
 
 resource "aws_secretsmanager_secret" "apiary_mysql_master_credentials" {
-  name = "apiary_db_master_user_${random_string.secret_seed_slug.result}"
-  tags = var.apiary_tags
+  count                   = "${var.external_database_host == "" ? var.db_instance_count : 0}"
+  name                    = "apiary_db_master_user_${random_string.secret_seed_slug.result}"
+  tags                    = var.apiary_tags
   recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "apiary_mysql_master_credentials" {
+  count         = "${var.external_database_host == "" ? var.db_instance_count : 0}"
   secret_id     = aws_secretsmanager_secret.apiary_mysql_master_credentials.id
   secret_string = jsonencode(
     map(

--- a/db.tf
+++ b/db.tf
@@ -89,7 +89,9 @@ resource "aws_rds_cluster_instance" "apiary_cluster_instance" {
   }
 }
 
-resource "random_string" "secret_seed_slug" {
+# In order to avoid resource collision when deleting & immediately recreating SecretsManager secrets in AWS, we set a random suffix on the name of the secret.
+# This allows us to avoid the issue of AWS's imposed 7 day recovery window.
+resource "random_string" "secret_name_suffix" {
   count   = "${var.external_database_host == "" ? var.db_instance_count : 0}"
   length  = 8
   special = false
@@ -97,7 +99,7 @@ resource "random_string" "secret_seed_slug" {
 
 resource "aws_secretsmanager_secret" "apiary_mysql_master_credentials" {
   count                   = "${var.external_database_host == "" ? var.db_instance_count : 0}"
-  name                    = "apiary_db_master_user_${random_string.secret_seed_slug.result}"
+  name                    = "apiary_db_master_user_${random_string.secret_name_suffix.result}"
   tags                    = var.apiary_tags
   recovery_window_in_days = 0
 }

--- a/iam-policy-secretsmanager.tf
+++ b/iam-policy-secretsmanager.tf
@@ -51,7 +51,7 @@ resource "aws_iam_role_policy" "secretsmanager_for_ecs_task_exec" {
           "${join("\",\"", concat(data.aws_secretsmanager_secret.docker_registry.*.arn))}",
           "${data.aws_secretsmanager_secret.db_rw_user.arn}",
           "${data.aws_secretsmanager_secret.db_ro_user.arn}",
-          "${aws_secretsmanager_secret.apiary_mysql_master_credentials.arn}"
+          "${aws_secretsmanager_secret.apiary_mysql_master_credentials[0].arn}"
         ]
     }
 }

--- a/iam-policy-secretsmanager.tf
+++ b/iam-policy-secretsmanager.tf
@@ -47,7 +47,12 @@ resource "aws_iam_role_policy" "secretsmanager_for_ecs_task_exec" {
     "Statement": {
         "Effect": "Allow",
         "Action": "secretsmanager:GetSecretValue",
-        "Resource": [ "${join("\",\"", concat(data.aws_secretsmanager_secret.docker_registry.*.arn))}" ]
+        "Resource": [ 
+          "${join("\",\"", concat(data.aws_secretsmanager_secret.docker_registry.*.arn))}",
+          "${data.aws_secretsmanager_secret.db_rw_user.arn}",
+          "${data.aws_secretsmanager_secret.db_ro_user.arn}",
+          "${aws_secretsmanager_secret.apiary_mysql_master_credentials.arn}"
+        ]
     }
 }
 EOF

--- a/k8s-readonly.tf
+++ b/k8s-readonly.tf
@@ -42,7 +42,7 @@ resource "kubernetes_deployment" "apiary_hms_readonly" {
           name  = "${local.hms_alias}-sql-init-readonly"
           
           command = ["sh allow-grant.sh"]
-          
+
           env {
             name = "MYSQL_HOST",
             value = var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.endpoint) : var.external_database_host
@@ -56,6 +56,22 @@ resource "kubernetes_deployment" "apiary_hms_readonly" {
           env {
             name = "MYSQL_PERMISSIONS",
             value = "SELECT"
+          }
+
+          env_from {
+            name = "MYSQL_MASTER_CREDS"
+            secret_key_ref {
+              name: kubernetes_secret.hms_secrets[0].metadata.name
+              key: "master_creds"
+            }
+          }
+
+          env_from {
+            name = "MYSQL_USER_CREDS"
+            secret_key_ref {
+              name: kubernetes_secret.hms_secrets[0].metadata.name
+              key: "ro_creds"
+            }
           }
         }
 

--- a/k8s-readonly.tf
+++ b/k8s-readonly.tf
@@ -37,6 +37,28 @@ resource "kubernetes_deployment" "apiary_hms_readonly" {
       }
 
       spec {
+        init_container {
+          image = "${var.init_container_image}:${var.init_container_version}"
+          name  = "${local.hms_alias}-sql-init-readonly"
+          
+          command = ["sh allow-grant.sh"]
+          
+          env {
+            name = "MYSQL_HOST",
+            value = var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.endpoint) : var.external_database_host
+          }
+
+          env {
+            name = "MYSQL_DB",
+            value = var.apiary_database_name
+          }
+
+          env {
+            name = "MYSQL_PERMISSIONS",
+            value = "SELECT"
+          }
+        }
+
         container {
           image = "${var.hms_docker_image}:${var.hms_docker_version}"
           name  = "${local.hms_alias}-readonly"

--- a/k8s-readwrite.tf
+++ b/k8s-readwrite.tf
@@ -37,6 +37,28 @@ resource "kubernetes_deployment" "apiary_hms_readwrite" {
       }
 
       spec {
+        init_container {
+          image = "${var.init_container_image}:${var.init_container_version}"
+          name  = "${local.hms_alias}-sql-init-readwrite"
+          
+          command = ["sh allow-grant.sh"]
+
+          env {
+            name = "MYSQL_HOST",
+            value = var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.endpoint) : var.external_database_host
+          }
+
+          env {
+            name = "MYSQL_DB",
+            value = var.apiary_database_name
+          }
+
+          env {
+            name = "MYSQL_PERMISSIONS",
+            value = "ALL"
+          }
+        }
+
         container {
           image = "${var.hms_docker_image}:${var.hms_docker_version}"
           name  = "${local.hms_alias}-readwrite"

--- a/k8s-readwrite.tf
+++ b/k8s-readwrite.tf
@@ -57,6 +57,22 @@ resource "kubernetes_deployment" "apiary_hms_readwrite" {
             name = "MYSQL_PERMISSIONS",
             value = "ALL"
           }
+
+          env_from {
+            name = "MYSQL_MASTER_CREDS"
+            secret_key_ref {
+              name: kubernetes_secret.hms_secrets[0].metadata.name
+              key: "master_creds"
+            }
+          }
+
+          env_from {
+            name = "MYSQL_USER_CREDS"
+            secret_key_ref {
+              name: kubernetes_secret.hms_secrets[0].metadata.name
+              key: "rw_creds"
+            }
+          }
         }
 
         container {

--- a/k8s-readwrite.tf
+++ b/k8s-readwrite.tf
@@ -37,40 +37,47 @@ resource "kubernetes_deployment" "apiary_hms_readwrite" {
       }
 
       spec {
-        init_container {
-          image = "${var.init_container_image}:${var.init_container_version}"
-          name  = "${local.hms_alias}-sql-init-readwrite"
-          
-          command = ["sh allow-grant.sh"]
+         dynamic "init_container" {
+           for_each = var.external_database_host == "" ? ["enabled"] : []
+           content {
+            image = "${var.init_container_image}:${var.init_container_version}"
+            name  = "${local.hms_alias}-sql-init-readwrite"
+            
+            command = ["sh allow-grant.sh"]
 
-          env {
-            name = "MYSQL_HOST",
-            value = var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.endpoint) : var.external_database_host
-          }
-
-          env {
-            name = "MYSQL_DB",
-            value = var.apiary_database_name
-          }
-
-          env {
-            name = "MYSQL_PERMISSIONS",
-            value = "ALL"
-          }
-
-          env_from {
-            name = "MYSQL_MASTER_CREDS"
-            secret_key_ref {
-              name: kubernetes_secret.hms_secrets[0].metadata.name
-              key: "master_creds"
+            env {
+              name = "MYSQL_HOST"
+              value = var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.endpoint) : var.external_database_host
             }
-          }
 
-          env_from {
-            name = "MYSQL_USER_CREDS"
-            secret_key_ref {
-              name: kubernetes_secret.hms_secrets[0].metadata.name
-              key: "rw_creds"
+            env {
+              name = "MYSQL_DB"
+              value = var.apiary_database_name
+            }
+
+            env {
+              name = "MYSQL_PERMISSIONS"
+              value = "ALL"
+            }
+
+            env {
+              name = "MYSQL_MASTER_CREDS"
+              value_from {
+                secret_key_ref {
+                  name = kubernetes_secret.hms_secrets[0].metadata[0].name
+                  key = "master_creds"
+                }
+              }
+            }
+
+            env {
+              name = "MYSQL_USER_CREDS"
+              value_from {
+                secret_key_ref {
+                  name = kubernetes_secret.hms_secrets[0].metadata[0].name
+                  key = "rw_creds"
+                }
+              }
             }
           }
         }

--- a/k8s-secrets.tf
+++ b/k8s-secrets.tf
@@ -1,0 +1,15 @@
+resource "kubernetes_secret" "hms_secrets" {
+  count = "${var.hms_instance_type == "k8s" ? 1 : 0}"
+  metadata {
+    name      = "${local.hms_alias}-credentials"
+    namespace = "metastore"
+  }
+
+  data = {
+    master_creds = aws_secretsmanager_secret_version.apiary_mysql_master_credentials.secret_string
+    ro_creds = data.aws_secretsmanager_secret_version.db_ro_user.secret_string
+    rw_creds = data.aws_secretsmanager_secret_version.db_rw_user.secret_string
+  }
+
+  type = "kubernetes.io/basic-auth"
+}

--- a/k8s-secrets.tf
+++ b/k8s-secrets.tf
@@ -1,12 +1,12 @@
 resource "kubernetes_secret" "hms_secrets" {
-  count = "${var.hms_instance_type == "k8s" ? 1 : 0}"
+  count = "${var.external_database_host == "" && var.hms_instance_type == "k8s" ? 1 : 0}"
   metadata {
     name      = "${local.hms_alias}-credentials"
     namespace = "metastore"
   }
 
   data = {
-    master_creds = aws_secretsmanager_secret_version.apiary_mysql_master_credentials.secret_string
+    master_creds = aws_secretsmanager_secret_version.apiary_mysql_master_credentials[0].secret_string
     ro_creds = data.aws_secretsmanager_secret_version.db_ro_user.secret_string
     rw_creds = data.aws_secretsmanager_secret_version.db_rw_user.secret_string
   }

--- a/templates.tf
+++ b/templates.tf
@@ -55,10 +55,11 @@ data "template_file" "hms_readwrite" {
     s3_enable_logs      = local.enable_apiary_s3_log_management ? "1" : ""
 
     # Template vars for init container
+    init_container_enabled = var.external_database_host == "" ? true : false
     init_container_image = "${var.init_container_image}"
     init_container_version = "${var.init_container_version}"
     mysql_permissions = "ALL"
-    mysql_master_cred_arn = aws_secretsmanager_secret.apiary_mysql_master_credentials.arn
+    mysql_master_cred_arn = aws_secretsmanager_secret.apiary_mysql_master_credentials[0].arn
     mysql_user_cred_arn = data.aws_secretsmanager_secret.db_rw_user.arn
     mysql_commands = "sh allow-grant.sh"
   }
@@ -99,10 +100,11 @@ data "template_file" "hms_readonly" {
     docker_auth = "${var.docker_registry_auth_secret_name == "" ? "" : format("\"repositoryCredentials\" :{\n \"credentialsParameter\":\"%s\"\n},", join("\",\"", concat(data.aws_secretsmanager_secret.docker_registry.*.arn)))}"
 
     # Template vars for init container
+    init_container_enabled = var.external_database_host == "" ? true : false
     init_container_image = "${var.init_container_image}"
     mysql_permissions = "SELECT"
     mysql_write_db = "${var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.endpoint) : var.external_database_host}"
-    mysql_master_cred_arn = aws_secretsmanager_secret.apiary_mysql_master_credentials.arn
+    mysql_master_cred_arn = aws_secretsmanager_secret.apiary_mysql_master_credentials[0].arn
     mysql_user_cred_arn = data.aws_secretsmanager_secret.db_ro_user.arn
     mysql_commands = "sh allow-grant.sh"
   }

--- a/templates.tf
+++ b/templates.tf
@@ -53,6 +53,14 @@ data "template_file" "hms_readwrite" {
     s3_enable_inventory = var.s3_enable_inventory ? "1" : ""
     # If user sets "apiary_log_bucket", then they are doing their own access logs mgmt, and not using Apiary's log mgmt.
     s3_enable_logs      = local.enable_apiary_s3_log_management ? "1" : ""
+
+    # Template vars for init container
+    init_container_image = "${var.init_container_image}"
+    init_container_version = "${var.init_container_version}"
+    mysql_permissions = "ALL"
+    mysql_master_cred_arn = aws_secretsmanager_secret.apiary_mysql_master_credentials.arn
+    mysql_user_cred_arn = data.aws_secretsmanager_secret.db_rw_user.arn
+    mysql_commands = "sh allow-grant.sh"
   }
 }
 
@@ -89,5 +97,13 @@ data "template_file" "hms_readonly" {
 
     #to instruct ECS to use repositoryCredentials for private docker registry
     docker_auth = "${var.docker_registry_auth_secret_name == "" ? "" : format("\"repositoryCredentials\" :{\n \"credentialsParameter\":\"%s\"\n},", join("\",\"", concat(data.aws_secretsmanager_secret.docker_registry.*.arn)))}"
+
+    # Template vars for init container
+    init_container_image = "${var.init_container_image}"
+    mysql_permissions = "SELECT"
+    mysql_write_db = "${var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.endpoint) : var.external_database_host}"
+    mysql_master_cred_arn = aws_secretsmanager_secret.apiary_mysql_master_credentials.arn
+    mysql_user_cred_arn = data.aws_secretsmanager_secret.db_ro_user.arn
+    mysql_commands = "sh allow-grant.sh"
   }
 }

--- a/templates/apiary-hms-readonly.json
+++ b/templates/apiary-hms-readonly.json
@@ -1,4 +1,5 @@
 [
+%{ if init_container_enabled }
   {
     "name": "mysql-setup",
     "essential": false,
@@ -40,6 +41,7 @@
     "workingDirectory": "/init",
     "command": ["${mysql_commands}"]
   },
+%{ endif } 
   {
     "name": "apiary-hms-readonly",
     "image": "${hms_docker_image}:${hms_docker_version}",
@@ -66,12 +68,14 @@
         "hostPort": 9083
       }
     ],
+%{ if init_container_enabled }
     "dependsOn": [
       {
         "containerName": "mysql-setup",
         "condition": "SUCCESS"
       }
     ],
+%{ endif } 
     "environment":[
       {
         "name": "MYSQL_DB_HOST",

--- a/templates/apiary-hms-readonly.json
+++ b/templates/apiary-hms-readonly.json
@@ -1,5 +1,46 @@
 [
   {
+    "name": "mysql-setup",
+    "essential": false,
+    "image": "${var.init_container_image}:${var.init_container_version}",
+    ${docker_auth}
+    "logConfiguration": {
+       "logDriver": "awslogs",
+       "options": {
+           "awslogs-group": "${loggroup}",
+           "awslogs-region": "${region}",
+           "awslogs-stream-prefix": "/"
+       }
+     },
+    "environment": [
+       {
+          "name": "MYSQL_HOST",
+          "value": "${mysql_write_db}"
+       },
+       {
+          "name": "MYSQL_DB",
+          "value": "${mysql_db_name}"
+       },
+       {
+          "name": "MYSQL_PERMISSIONS",
+          "value": "${mysql_permissions}"
+       }
+    ],
+    "secrets": [
+       {
+         "valueFrom": "${mysql_master_cred_arn}",
+         "name": "MYSQL_MASTER_CREDS"
+       },
+       {
+         "valueFrom": "${mysql_user_cred_arn}",
+         "name": "MYSQL_USER_CREDS"
+       }
+    ],
+    "entryPoint": [ "/bin/sh", "-c" ],
+    "workingDirectory": "/init",
+    "command": ["${mysql_commands}"]
+  },
+  {
     "name": "apiary-hms-readonly",
     "image": "${hms_docker_image}:${hms_docker_version}",
     ${docker_auth}
@@ -23,6 +64,12 @@
       {
         "containerPort": 9083,
         "hostPort": 9083
+      }
+    ],
+    "dependsOn": [
+      {
+        "containerName": "mysql-setup",
+        "condition": "SUCCESS"
       }
     ],
     "environment":[

--- a/templates/apiary-hms-readwrite.json
+++ b/templates/apiary-hms-readwrite.json
@@ -1,4 +1,44 @@
-[
+[  {
+   "name": "mysql-setup",
+   "essential": false,
+   "image": "${var.init_container_image}:${var.init_container_version}",
+   ${docker_auth}
+   "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+          "awslogs-group": "${loggroup}",
+          "awslogs-region": "${region}",
+          "awslogs-stream-prefix": "/"
+      }
+    },
+   "environment": [
+      {
+         "name": "MYSQL_HOST",
+         "value": "${mysql_db_host}"
+      },
+      {
+         "name": "MYSQL_DB",
+         "value": "${mysql_db_name}"
+      },
+      {
+         "name": "MYSQL_PERMISSIONS",
+         "value": "${mysql_permissions}"
+      }
+   ],
+   "secrets": [
+      {
+        "valueFrom": "${mysql_master_cred_arn}",
+        "name": "MYSQL_MASTER_CREDS"
+      },
+      {
+        "valueFrom": "${mysql_user_cred_arn}",
+        "name": "MYSQL_USER_CREDS"
+      }
+   ],
+   "entryPoint": [ "/bin/sh", "-c" ],
+   "workingDirectory": "/init",
+   "command": ["${mysql_commands}"]
+  },
   {
     "name": "apiary-hms-readwrite",
     "image": "${hms_docker_image}:${hms_docker_version}",
@@ -23,6 +63,12 @@
       {
         "containerPort": 9083,
         "hostPort": 9083
+      }
+    ],
+    "dependsOn": [
+      {
+        "containerName": "mysql-setup",
+        "condition": "SUCCESS"
       }
     ],
     "environment":[

--- a/templates/apiary-hms-readwrite.json
+++ b/templates/apiary-hms-readwrite.json
@@ -1,44 +1,47 @@
-[  {
-   "name": "mysql-setup",
-   "essential": false,
-   "image": "${var.init_container_image}:${var.init_container_version}",
-   ${docker_auth}
-   "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
+[
+%{ if init_container_enabled }
+  {
+    "name": "mysql-setup",
+    "essential": false,
+    "image": "${var.init_container_image}:${var.init_container_version}",
+    ${docker_auth}
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
           "awslogs-group": "${loggroup}",
           "awslogs-region": "${region}",
           "awslogs-stream-prefix": "/"
-      }
+        }
     },
-   "environment": [
-      {
-         "name": "MYSQL_HOST",
-         "value": "${mysql_db_host}"
-      },
-      {
-         "name": "MYSQL_DB",
-         "value": "${mysql_db_name}"
-      },
-      {
-         "name": "MYSQL_PERMISSIONS",
-         "value": "${mysql_permissions}"
-      }
-   ],
-   "secrets": [
-      {
+    "environment": [
+        {
+          "name": "MYSQL_HOST",
+          "value": "${mysql_db_host}"
+        },
+        {
+          "name": "MYSQL_DB",
+          "value": "${mysql_db_name}"
+        },
+        {
+          "name": "MYSQL_PERMISSIONS",
+          "value": "${mysql_permissions}"
+        }
+    ],
+    "secrets": [
+        {
         "valueFrom": "${mysql_master_cred_arn}",
         "name": "MYSQL_MASTER_CREDS"
-      },
-      {
+        },
+        {
         "valueFrom": "${mysql_user_cred_arn}",
         "name": "MYSQL_USER_CREDS"
-      }
-   ],
-   "entryPoint": [ "/bin/sh", "-c" ],
-   "workingDirectory": "/init",
-   "command": ["${mysql_commands}"]
+        }
+    ],
+    "entryPoint": [ "/bin/sh", "-c" ],
+    "workingDirectory": "/init",
+    "command": ["${mysql_commands}"]
   },
+%{ endif }
   {
     "name": "apiary-hms-readwrite",
     "image": "${hms_docker_image}:${hms_docker_version}",
@@ -65,12 +68,14 @@
         "hostPort": 9083
       }
     ],
+%{ if init_container_enabled }
     "dependsOn": [
       {
         "containerName": "mysql-setup",
         "condition": "SUCCESS"
       }
     ],
+%{ endif }
     "environment":[
      {
         "name": "MYSQL_DB_HOST",

--- a/variables.tf
+++ b/variables.tf
@@ -444,3 +444,16 @@ variable "system_schema_name" {
   type        = string
   default     = "apiary_system"
 }
+
+
+variable "init_container_image" {
+  description = "Docker image for running HMS init container."
+  type        = string
+  default     = "tbd"
+}
+
+variable "init_container_version" {
+  description = "Docker image version for running HMS init container."
+  type        = string
+  default     = "0.0.1"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -453,13 +453,13 @@ variable "system_schema_name" {
 
 
 variable "init_container_image" {
-  description = "Docker image for running HMS init container."
+  description = "Docker image for running HMS init container. Required if `external_database_host` is unset."
   type        = string
-  default     = "tbd"
+  default     = ""
 }
 
 variable "init_container_version" {
-  description = "Docker image version for running HMS init container."
+  description = "Docker image version for running HMS init container. Required if `external_database_host` is unset."
   type        = string
-  default     = "0.0.1"
+  default     = ""
 }


### PR DESCRIPTION
REQUIREMENT: https://github.com/ExpediaGroup/apiary-metastore-docker/pull/78

## [6.5.0] - 2020-08-31
### Changed
- [Issue 165](https://github.com/ExpediaGroup/apiary-data-lake/issues/165) Use init containers instead of `mysql` commands to initialize mysql users.

### Removed
- `mysql` dependency for this terraform module.

Note: I currently don't have a fantastic method of testing the kubernetes deployment. Is there a good setup for testing that side of it?
