### PR TITLE
Enable HMS Schema Deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.5.0] - TBD
+### Added
+- Add the option of deleting certain Hive databases when the metastore starts up. This will only delete metadata from the HMS, not actual S3 data or buckets. Will also enable cascading-deletes on the MySQL tables before deleting, then will remove cascading-deletes. See variables `enable_schema_deletion` and `apiary_delete_schemas` in [VARIABLES.md](VARIABLES.md).
+
 ## [6.4.3] - 2020-08-12
 ### Fixed
 - [Issue 169](https://github.com/ExpediaGroup/apiary-data-lake/issues/169) Added S3:GetBucketAcl to cross-account shared buckets

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -12,7 +12,7 @@
 | apiary_log_bucket | Bucket for Apiary logs. | string | - | yes |
 | apiary_log_prefix | Prefix for Apiary logs. | string | `` | no |
 | apiary_managed_schemas | List of maps - each map entry describes an Apiary schema, along with S3 storage properties for the schema. See section [`apiary_managed_schemas`](#apiary_managed_schemas) for more info. | list(map) | - | no |
-| apiary_delete_schemas | List of maps - each map contains schema name which will be deleted from the Hive metastore, and its corresponding S3 bucket deleted. | list(map) | - | no |
+| apiary_delete_schemas | List of maps - each map contains schema name which will be deleted from the Hive metastore. This will NOT delete the corresponding S3 data. | list(map) | - | no |
 | apiary_producer_iamroles | AWS IAM roles allowed write access to managed Apiary S3 buckets. | map | `<map>` | no |
 | apiary_rds_additional_sg | Comma-separated string containing additional security groups to attach to RDS. | list | `<list>` | no |
 | apiary_shared_schemas | Schema names which are accessible from read-only metastore, default is all schemas. | list | `<list>` | no |

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -137,3 +137,22 @@ Name | Description | Type | Default | Required |
 | encryption | S3 objects encryption type, supported values are AES256,aws:kms. | string | null | no |
 | admin_roles | IAM roles configured with admin access on corresponding KMS keys,required when encryption type is `aws:kms`. | string | null | no |
 | client_roles | IAM roles configured with usage access on corresponding KMS keys,required when encryption type is `aws:kms`. | string | null | no |
+
+### apiary_delete_schemas
+
+A list of maps. Aach map contains the schema name which will be deleted from the Hive metastore. Entry is a list of maps to allow for future properties in each entry that will control optional delete-time functionality.
+
+An example entry looks like:
+```
+apiary_delete_schemas = [
+  {
+   schema_name = "deleteme_schema"
+  }
+]
+```
+
+`apiary_delete_schemas` map entry fields:
+
+Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| schema_name | Name of the schema to be deleted. | string | - | yes |

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -12,6 +12,7 @@
 | apiary_log_bucket | Bucket for Apiary logs. | string | - | yes |
 | apiary_log_prefix | Prefix for Apiary logs. | string | `` | no |
 | apiary_managed_schemas | List of maps - each map entry describes an Apiary schema, along with S3 storage properties for the schema. See section [`apiary_managed_schemas`](#apiary_managed_schemas) for more info. | list(map) | - | no |
+| apiary_delete_schemas | List of maps - each map contains schema name which will be deleted from the Hive metastore, and its corresponding S3 bucket deleted. | list(map) | - | no |
 | apiary_producer_iamroles | AWS IAM roles allowed write access to managed Apiary S3 buckets. | map | `<map>` | no |
 | apiary_rds_additional_sg | Comma-separated string containing additional security groups to attach to RDS. | list | `<list>` | no |
 | apiary_shared_schemas | Schema names which are accessible from read-only metastore, default is all schemas. | list | `<list>` | no |
@@ -35,6 +36,7 @@
 | enable_gluesync | Enable metadata sync from Hive to the Glue catalog. | bool | `false` | no |
 | enable_hive_metastore_metrics | Enable sending Hive Metastore metrics to CloudWatch. | bool | `false` | no |
 | enable_metadata_events | Enable Hive Metastore SNS listener. | bool | `false` | no |
+| enable_schema_deletion | Enable deletion of Hive schemas (from `var.apiary_delete_schemas`) when HMS starts. | bool | `false` | no |
 | enable_s3_paid_metrics | Enable managed S3 buckets request and data transfer metrics. | bool | `false` | no |
 | enable_vpc_endpoint_services | Enable metastore VPC endpoint services,for cross-account access. | bool | `true` | no |
 | external_data_buckets | Buckets that are not managed by Apiary but added to Hive Metastore IAM role access. | list | `<list>` | no |

--- a/k8s-readwrite.tf
+++ b/k8s-readwrite.tf
@@ -76,6 +76,14 @@ resource "kubernetes_deployment" "apiary_hms_readwrite" {
             value = join(",", local.schemas_info[*]["schema_name"])
           }
           env {
+            name  = "HIVE_DBS_TO_DELETE"
+            value = join(",", var.apiary_delete_schemas[*]["schema_name"])
+          }
+          env {
+            name  = "ENABLE_SCHEMA_DELETION"
+            value = var.enable_schema_deletion ? "1" : ""
+          }
+          env {
             name  = "INSTANCE_NAME"
             value = local.instance_alias
           }

--- a/templates.tf
+++ b/templates.tf
@@ -23,6 +23,8 @@ data "template_file" "hms_readwrite" {
     nofile_ulimit              = "${var.hms_nofile_ulimit}"
     enable_metrics             = var.enable_hive_metastore_metrics ? "1" : ""
     managed_schemas            = join(",", local.schemas_info[*]["schema_name"])
+    delete_schemas             = join(",", var.apiary_delete_schemas[*]["schema_name"])
+    enable_schema_deletion     = var.enable_schema_deletion ? "1" : ""
     instance_name              = "${local.instance_alias}"
     sns_arn                    = var.enable_metadata_events ? join("", aws_sns_topic.apiary_metadata_events.*.arn) : ""
     table_param_filter         = var.enable_metadata_events ? var.table_param_filter : ""

--- a/templates/apiary-hms-readwrite.json
+++ b/templates/apiary-hms-readwrite.json
@@ -55,6 +55,14 @@
         "value": "${managed_schemas}"
      },
      {
+        "name": "HIVE_DBS_TO_DELETE",
+        "value": "${delete_schemas}"
+     },
+     {
+        "name": "ENABLE_SCHEMA_DELETION",
+        "value": "${enable_schema_deletion}"
+     },
+     {
         "name": "INSTANCE_NAME",
         "value": "${instance_name}"
      },

--- a/variables.tf
+++ b/variables.tf
@@ -79,7 +79,7 @@ variable "apiary_managed_schemas" {
 }
 
 variable "apiary_delete_schemas" {
-  description = "List of maps, each map contains schema name which will be deleted from the Hive metastore, and its corresponding S3 bucket deleted."
+  description = "List of maps, each map contains the schema name which will be deleted from the Hive metastore. Entry is a list of maps to allow for future properties in each entry that will control optional delete-time functionality."
   type        = list(map(string))
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -78,6 +78,18 @@ variable "apiary_managed_schemas" {
   default     = []
 }
 
+variable "apiary_delete_schemas" {
+  description = "List of maps, each map contains schema name which will be deleted from the Hive metastore, and its corresponding S3 bucket deleted."
+  type        = list(map(string))
+  default     = []
+}
+
+variable "enable_schema_deletion" {
+  description = "Boolean to enable schema deletion. If false, then any schemas in 'apiary_delete_schemas' will not be deleted."
+  type        = bool
+  default     = false
+}
+
 variable "external_data_buckets" {
   description = "Buckets that are not managed by Apiary but added to Hive Metastore IAM role access."
   type        = list(any)


### PR DESCRIPTION
Add a feature to delete HMS metadata for a list of schemas specified in the `apiary_delete_schemas` variable.

Corresponding Metastore PR: https://github.com/ExpediaGroup/apiary-metastore-docker/pull/79