### PR TITLE
add metastore load balancer outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.5.3] - 2020-10-09
+### Added
+- Add metastore load balancer outputs.
+
 ## [6.5.2] - 2020-09-08
 ### Changed
 - Enable SQS events on managed logs bucket.

--- a/ouputs.tf
+++ b/ouputs.tf
@@ -1,0 +1,7 @@
+output "hms_readonly_load_balancers" {
+  value = var.hms_instance_type == "k8s" ? kubernetes_service.hms_readonly[0].load_balancer_ingress.*.hostname : []
+}
+
+output "hms_readwrite_load_balancers" {
+  value = var.hms_instance_type == "k8s" ? kubernetes_service.hms_readwrite[0].load_balancer_ingress.*.hostname : []
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description
 Add terraform outputs for metastore load balancers, so that we can use outputs to create CNAMEs accessible from corp network.

### :link: Related Issues