### PR TITLE
Feature/s3 object ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.6.0] - 2020-10-30
+### Added
+- Configure bucket ownership controls on apiary managed buckets,cross account object writes will be owned by bucket instead of writer.
+
 ## [6.5.3] - 2020-10-09
 ### Added
 - Add metastore load balancer outputs.

--- a/s3-other.tf
+++ b/s3-other.tf
@@ -49,6 +49,15 @@ resource "aws_s3_bucket_public_access_block" "apiary_inventory_bucket" {
   ignore_public_acls  = true
 }
 
+resource "aws_s3_bucket_ownership_controls" "apiary_inventory_bucket" {
+  count  = var.s3_enable_inventory == true ? 1 : 0
+  bucket = aws_s3_bucket.apiary_inventory_bucket[0].bucket
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket" "apiary_managed_logs_bucket" {
   count  = local.enable_apiary_s3_log_management ? 1 : 0
   bucket = local.apiary_s3_logs_bucket

--- a/s3.tf
+++ b/s3.tf
@@ -106,6 +106,17 @@ resource "aws_s3_bucket_public_access_block" "apiary_bucket" {
   ignore_public_acls  = true
 }
 
+resource "aws_s3_bucket_ownership_controls" "apiary_bucket" {
+  for_each = {
+    for schema in local.schemas_info : "${schema["schema_name"]}" => schema
+  }
+  bucket = aws_s3_bucket.apiary_data_bucket[each.key].id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_notification" "data_events" {
   for_each = var.enable_data_events ? {
     for schema in local.schemas_info : "${schema["schema_name"]}" => schema if lookup(schema, "enable_data_events_sqs", "0") == "0"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description
Add aws_s3_bucket_ownership_controls terraform resource for all apiary managed buckets,cross account object writes will be owned by bucket instead of writer.

### :link: Related Issues