### PR TITLE
variable to enable s3 logs hive database.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.7.4] - 2021-03-01
+### Changed
+- Only publish S3 Create events to managed logs SQS queue.
+- Variable to disable creating s3 logs hive database.
+
 ## [6.7.3] - 2021-03-01
 ### Changed
 - Terraform 0.12+ formatting.

--- a/common.tf
+++ b/common.tf
@@ -32,6 +32,7 @@ locals {
   s3_inventory_bucket             = var.s3_enable_inventory ? "${local.apiary_bucket_prefix}-s3-inventory" : ""
   create_sqs_data_event_queue     = contains([for schema in local.schemas_info : lookup(schema, "enable_data_events_sqs", "0")], "1") ? true : false
   enable_apiary_s3_log_management = var.apiary_log_bucket == "" ? true : false
+  enable_apiary_s3_log_hive       = var.apiary_log_bucket == "" && var.enable_apiary_s3_log_hive ? true : false
   apiary_s3_logs_bucket           = local.enable_apiary_s3_log_management ? "${local.apiary_bucket_prefix}-s3-logs" : ""
   apiary_s3_hive_logs_bucket      = local.enable_apiary_s3_log_management ? "${local.apiary_s3_logs_bucket}-hive" : ""
   apiary_system_bucket            = "${local.apiary_bucket_prefix}-${replace(var.system_schema_name, "_", "-")}"

--- a/k8s-readwrite.tf
+++ b/k8s-readwrite.tf
@@ -191,7 +191,7 @@ resource "kubernetes_deployment" "apiary_hms_readwrite" {
           env {
             # If user sets "apiary_log_bucket", then they are doing their own access logs mgmt, and not using Apiary's log mgmt.
             name  = "ENABLE_S3_LOGS"
-            value = local.enable_apiary_s3_log_management ? "1" : ""
+            value = local.enable_apiary_s3_log_hive ? "1" : ""
           }
           env {
             name  = "HMS_MIN_THREADS"

--- a/s3-other.tf
+++ b/s3-other.tf
@@ -103,12 +103,12 @@ resource "aws_s3_bucket_notification" "apiary_managed_logs_bucket" {
 
   queue {
     queue_arn = aws_sqs_queue.apiary_managed_logs_queue[0].arn
-    events    = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+    events    = ["s3:ObjectCreated:*"]
   }
 }
 
 resource "aws_s3_bucket" "apiary_access_logs_hive" {
-  count  = local.enable_apiary_s3_log_management ? 1 : 0
+  count  = local.enable_apiary_s3_log_hive ? 1 : 0
   bucket = local.apiary_s3_hive_logs_bucket
   tags   = merge(map("Name", local.apiary_s3_hive_logs_bucket), var.apiary_tags)
   acl    = "private"
@@ -127,7 +127,7 @@ resource "aws_s3_bucket" "apiary_access_logs_hive" {
 }
 
 resource "aws_s3_bucket_public_access_block" "apiary_access_logs_hive" {
-  count  = local.enable_apiary_s3_log_management ? 1 : 0
+  count  = local.enable_apiary_s3_log_hive ? 1 : 0
   bucket = aws_s3_bucket.apiary_access_logs_hive[0].bucket
 
   block_public_acls   = true

--- a/templates.tf
+++ b/templates.tf
@@ -52,7 +52,7 @@ data "template_file" "hms_readwrite" {
 
     s3_enable_inventory = var.s3_enable_inventory ? "1" : ""
     # If user sets "apiary_log_bucket", then they are doing their own access logs mgmt, and not using Apiary's log mgmt.
-    s3_enable_logs = local.enable_apiary_s3_log_management ? "1" : ""
+    s3_enable_logs = local.enable_apiary_s3_log_hive ? "1" : ""
 
     # Template vars for init container
     init_container_enabled = var.external_database_host == "" ? true : false

--- a/variables.tf
+++ b/variables.tf
@@ -49,7 +49,7 @@ variable "aws_region" {
 }
 
 variable "apiary_log_bucket" {
-  description = "Bucket for Apiary logs."
+  description = "Bucket for Apiary logs.If this is blank, module will create a bucket."
   type        = string
   default     = ""
 }
@@ -58,6 +58,12 @@ variable "apiary_log_prefix" {
   description = "Prefix for Apiary logs."
   type        = string
   default     = ""
+}
+
+variable "enable_apiary_s3_log_hive" {
+  description = "Create hive database to archive s3 logs in parquet format.Only applicable when module manages logs S3 bucket."
+  type        = bool
+  default     = true
 }
 
 variable "enable_hive_metastore_metrics" {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description
   Variable to enable s3 logs hive database
   Only publish S3 create events to logs SQS queue.

### :link: Related Issues