### PR TITLE
S3 HTTPS bucket policy requirements are now properly enforced.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.7.4] - 2021-03-01
+### Fixed
+- S3 HTTPS bucket policy requirements are now properly enforced.
+
 ## [6.7.3] - 2021-03-01
 ### Changed
 - Terraform 0.12+ formatting.

--- a/templates/apiary-bucket-policy.json
+++ b/templates/apiary-bucket-policy.json
@@ -83,7 +83,10 @@
                 "AWS": "*"
             },
             "Action": "s3:*",
-            "Resource": "arn:aws:s3:::${bucket_name}",
+            "Resource": [
+                "arn:aws:s3:::${bucket_name}",
+                "arn:aws:s3:::${bucket_name}/*",
+            ],
             "Condition": {
                 "Bool": {
                     "aws:SecureTransport": "false"

--- a/templates/apiary-bucket-policy.json
+++ b/templates/apiary-bucket-policy.json
@@ -85,7 +85,7 @@
             "Action": "s3:*",
             "Resource": [
                 "arn:aws:s3:::${bucket_name}",
-                "arn:aws:s3:::${bucket_name}/*",
+                "arn:aws:s3:::${bucket_name}/*"
             ],
             "Condition": {
                 "Bool": {


### PR DESCRIPTION
## [6.7.4] - 2021-03-01
### Fixed
- S3 HTTPS bucket policy requirements are now properly enforced.