### PR TITLE
Deny unsecure communication for internal Apiary buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [6.7.8] - 2021-03-30
+## [6.7.8] - 2021-04-01
 ### Changed
 - Added `DenyUnsecureCommunication` policy for `s3-other.tf` buckets.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.7.8] - 2021-03-30
+### Changed
+- Added `DenyUnsecureCommunication` policy for `s3-other.tf` buckets
+
 ## [6.7.7] - 2021-03-03
 ### Changed
 - Add variables to configure s3-sqs defaults for spark streaming.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [6.7.8] - 2021-03-30
 ### Changed
-- Added `DenyUnsecureCommunication` policy for `s3-other.tf` buckets
+- Added `DenyUnsecureCommunication` policy for `s3-other.tf` buckets.
 
 ## [6.7.7] - 2021-03-03
 ### Changed

--- a/s3-other.tf
+++ b/s3-other.tf
@@ -28,6 +28,21 @@ resource "aws_s3_bucket" "apiary_inventory_bucket" {
              "s3:x-amz-acl": "bucket-owner-full-control"
           }
        }
+    },
+    {
+      "Sid": "DenyUnSecureCommunications",
+      "Effect": "Deny",
+      "Principal": {"AWS": "*"},
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::${local.s3_inventory_bucket}",
+        "arn:aws:s3:::${local.s3_inventory_bucket}/*"
+        ],
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      }
     }
   ]
 }
@@ -63,7 +78,28 @@ resource "aws_s3_bucket" "apiary_managed_logs_bucket" {
   bucket = local.apiary_s3_logs_bucket
   acl    = "log-delivery-write"
   tags   = merge(map("Name", local.apiary_s3_logs_bucket), var.apiary_tags)
-
+  policy = <<EOF
+{
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Sid": "DenyUnSecureCommunications",
+      "Effect": "Deny",
+      "Principal": {"AWS": "*"},
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::${local.apiary_s3_logs_bucket}",
+        "arn:aws:s3:::${local.apiary_s3_logs_bucket}/*"
+        ],
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      }
+    }
+  ]
+}
+EOF
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
@@ -111,6 +147,28 @@ resource "aws_s3_bucket" "apiary_access_logs_hive" {
   count  = local.enable_apiary_s3_log_hive ? 1 : 0
   bucket = local.apiary_s3_hive_logs_bucket
   tags   = merge(map("Name", local.apiary_s3_hive_logs_bucket), var.apiary_tags)
+  policy = <<EOF
+{
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Sid": "DenyUnSecureCommunications",
+      "Effect": "Deny",
+      "Principal": {"AWS": "*"},
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::${local.apiary_s3_hive_logs_bucket}",
+        "arn:aws:s3:::${local.apiary_s3_hive_logs_bucket}/*"
+        ],
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      }
+    }
+  ]
+}
+EOF
   acl    = "private"
   server_side_encryption_configuration {
     rule {
@@ -138,6 +196,28 @@ resource "aws_s3_bucket_public_access_block" "apiary_access_logs_hive" {
 resource "aws_s3_bucket" "apiary_system" {
   bucket = local.apiary_system_bucket
   tags   = merge(map("Name", local.apiary_system_bucket), var.apiary_tags)
+  policy = <<EOF
+{
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Sid": "DenyUnSecureCommunications",
+      "Effect": "Deny",
+      "Principal": {"AWS": "*"},
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::${local.apiary_system_bucket}",
+        "arn:aws:s3:::${local.apiary_system_bucket}/*"
+        ],
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      }
+    }
+  ]
+}
+EOF
   acl    = "private"
   server_side_encryption_configuration {
     rule {


### PR DESCRIPTION
### :pencil: During audit it was noticed that internal Apiary buckets allow unsecure communication. Adding policy allows only HTTPS communication for those buckets. 

Verified in internal dev environment that internal AWS jobs that deliver files to those buckets are not interrupted by this change
