### PR TITLE
Support DB param groups and increase "max_allowed_packet"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.8.0] - 2021-05-10
+### Added
+- Add support for Apiary-specific RDS parameter groups.
+- Add variable to specify RDS/MySQL parameter value for `max_allowed_packet` (default 16MB).
+
 ## [6.7.9] - 2021-04-28
 ### Fixed
 - If the S3 bucket specifies an expiration TTL in days that is <= the Intelligent-Tiering transition days, don't create

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -64,6 +64,7 @@
 | ranger_audit_secret_name | Ranger DB audit secret name. | string | `` | no |
 | ranger_audit_solr_url | Ranger Solr audit provider configuration. | string | `` | no |
 | ranger_policy_manager_url | Ranger admin URL to synchronize policies. | string | `` | no |
+| rds_max_allowed_packet | RDS/MySQL setting for parameter 'max_allowed_packet' in bytes. | number | `16777216` | no |
 | s3_enable_inventory | Enable S3 inventory configuration. | bool | `false` | no |
 | s3_inventory_format | Output format for S3 inventory results. Can be Parquet, ORC, CSV | string | `ORC` | no |
 | s3_inventory_update_schedule | Cron schedule to update S3 inventory tables (if enabled). Defaults to every 12 hours. | string | `0 */12 * * *` | no |

--- a/db.tf
+++ b/db.tf
@@ -62,7 +62,7 @@ resource aws_rds_cluster_parameter_group "apiary_rds_param_group" {
 
   parameter {
     name  = "max_allowed_packet"
-    value = "16M"
+    value = var.rds_max_allowed_packet
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -480,3 +480,9 @@ variable "system_schema_name" {
   type        = string
   default     = "apiary_system"
 }
+
+variable "rds_max_allowed_packet" {
+  description = "RDS/MySQL setting for parameter 'max-allowed-packet'. Default is 16MB."
+  type        = number
+  default     = 16777216
+}

--- a/variables.tf
+++ b/variables.tf
@@ -482,7 +482,7 @@ variable "system_schema_name" {
 }
 
 variable "rds_max_allowed_packet" {
-  description = "RDS/MySQL setting for parameter 'max-allowed-packet'. Default is 16MB."
+  description = "RDS/MySQL setting for parameter 'max_allowed_packet' in bytes. Default is 16MB (Note that MySQL default is 4MB)."
   type        = number
   default     = 16777216
 }


### PR DESCRIPTION
## [6.8.0] - 2021-05-10
### Added
- Add support for Apiary-specific RDS parameter groups.
- Add variable to specify RDS/MySQL parameter value for `max_allowed_packet` (default 16MB).
