### PR TITLE
Add feature to provide governance iam role s3 read permission and put object tagging permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.11.2] - 2021-11-09
+### Added
+- Added governance role read and tag objects permission to apiary buckets
+
 ## [6.11.1] - 2021-11-02
 ### Added
 - s3 other bucket public access restrictions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [6.11.2] - 2021-11-09
+## [6.11.2] - 2021-11-12
 ### Added
 - Added governance role read and tag objects permission to apiary buckets
 

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -12,11 +12,11 @@
 | apiary\_deny\_iamrole\_actions | List of S3 actions that 'apiary\_deny\_iamroles' are not allowed to perform. | `list(string)` | <pre>[<br>  "s3:Abort*",<br>  "s3:Bypass*",<br>  "s3:Delete*",<br>  "s3:GetObject",<br>  "s3:GetObjectTorrent",<br>  "s3:GetObjectVersion",<br>  "s3:GetObjectVersionTorrent",<br>  "s3:ObjectOwnerOverrideToBucketOwner",<br>  "s3:Put*",<br>  "s3:Replicate*",<br>  "s3:Restore*"<br>]</pre> | no |
 | apiary\_deny\_iamroles | AWS IAM roles denied access to Apiary managed S3 buckets. | `list(string)` | `[]` | no |
 | apiary\_domain\_name | Apiary domain name for Route 53. | `string` | `""` | no |
+| apiary\_governance\_iamroles | AWS IAM governance roles allowed read and tagging access to managed Apiary S3 buckets. | `list(string)` | `[]` | no |
 | apiary\_log\_bucket | Bucket for Apiary logs.If this is blank, module will create a bucket. | `string` | `""` | no |
 | apiary\_log\_prefix | Prefix for Apiary logs. | `string` | `""` | no |
 | apiary\_managed\_schemas | List of maps, each map contains schema name from which S3 bucket names will be derived, and various properties. The corresponding S3 bucket will be named as apiary\_instance-aws\_account-aws\_region-schema\_name. | `list(map(string))` | `[]` | no |
 | apiary\_producer\_iamroles | AWS IAM roles allowed write access to managed Apiary S3 buckets. | `map(any)` | `{}` | no |
-| apiary\_governance\_iamroles | AWS IAM governance roles allowed read and tagging access to managed Apiary S3 buckets. | `list(string)` | `[]` | no |
 | apiary\_rds\_additional\_sg | Comma-separated string containing additional security groups to attach to RDS. | `list(any)` | `[]` | no |
 | apiary\_shared\_schemas | Schema names which are accessible from read-only metastore, default is all schemas. | `list(any)` | `[]` | no |
 | apiary\_tags | Common tags that get put on all resources. | `map(any)` | n/a | yes |

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -16,6 +16,7 @@
 | apiary\_log\_prefix | Prefix for Apiary logs. | `string` | `""` | no |
 | apiary\_managed\_schemas | List of maps, each map contains schema name from which S3 bucket names will be derived, and various properties. The corresponding S3 bucket will be named as apiary\_instance-aws\_account-aws\_region-schema\_name. | `list(map(string))` | `[]` | no |
 | apiary\_producer\_iamroles | AWS IAM roles allowed write access to managed Apiary S3 buckets. | `map(any)` | `{}` | no |
+| apiary\_governance\_iamroles | AWS IAM governance roles allowed read and tagging access to managed Apiary S3 buckets. | `list(string)` | `[]` | no |
 | apiary\_rds\_additional\_sg | Comma-separated string containing additional security groups to attach to RDS. | `list(any)` | `[]` | no |
 | apiary\_shared\_schemas | Schema names which are accessible from read-only metastore, default is all schemas. | `list(any)` | `[]` | no |
 | apiary\_tags | Common tags that get put on all resources. | `map(any)` | n/a | yes |

--- a/s3.tf
+++ b/s3.tf
@@ -27,6 +27,7 @@ data "template_file" "bucket_policy" {
     deny_iamroles        = join("\",\"", var.apiary_deny_iamroles)
     deny_iamrole_actions = join("\",\"", var.apiary_deny_iamrole_actions)
     client_roles         = replace(lookup(each.value, "client_roles", ""), ",", "\",\"")
+    governance_iamroles  = join("\",\"", var.apiary_governance_iamroles)
   }
 }
 

--- a/templates/apiary-bucket-policy.json
+++ b/templates/apiary-bucket-policy.json
@@ -129,6 +129,28 @@
             }
         },
 %{endif}
+%{if governance_iamroles != ""}
+        {
+            "Sid": "Apiary consumer iamrole permissions",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": [ "${governance_iamroles}" ]
+            },
+            "Action": [
+                "s3:GetBucketLocation",
+                "s3:GetObject",
+                "s3:GetObjectAcl",
+                "s3:GetBucketAcl",
+                "s3:GetObjectTagging",
+                "s3:ListBucket",
+                "s3:PutObjectTagging"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${bucket_name}",
+                "arn:aws:s3:::${bucket_name}/*"
+            ]
+        },
+%{endif}
         {
             "Sid": "DenyUnSecureCommunications",
             "Effect": "Deny",

--- a/templates/apiary-bucket-policy.json
+++ b/templates/apiary-bucket-policy.json
@@ -131,7 +131,7 @@
 %{endif}
 %{if governance_iamroles != ""}
         {
-            "Sid": "Apiary consumer iamrole permissions",
+            "Sid": "Apiary governance iamrole permissions",
             "Effect": "Allow",
             "Principal": {
                 "AWS": [ "${governance_iamroles}" ]

--- a/variables.tf
+++ b/variables.tf
@@ -571,7 +571,7 @@ variable "disallow_incompatible_col_type_changes" {
 }
 
 variable "apiary_governance_iamroles" {
-  description = "AWS IAM roles allowed read access to managed Apiary S3 buckets."
+  description = "AWS IAM governance roles allowed read and tagging access to managed Apiary S3 buckets."
   type        = list(string)
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -569,3 +569,9 @@ variable "disallow_incompatible_col_type_changes" {
   type        = bool
   default     = true
 }
+
+variable "apiary_governance_iamroles" {
+  description = "AWS IAM roles allowed read access to managed Apiary S3 buckets."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description


### :link: Related Issues