### PR TITLE
ecs sm policy & template fix with external_database_host 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.12.3] - 2022-05-31
+### Fixed
+- Fixed SM policy & templates for resource apiary_mysql_master_credentials when external_database_host is in use.
+
 ## [6.12.2] - 2022-05-20
 ### Added
 - Add ability to configure size of HMS MySQL connection pool, and configure stats computation on table/partition creation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [6.12.3] - 2022-05-31
+## [6.12.3] - 2022-06-01
 ### Fixed
 - Fixed SM policy & templates for resource apiary_mysql_master_credentials when external_database_host is in use.
 

--- a/iam-policy-secretsmanager.tf
+++ b/iam-policy-secretsmanager.tf
@@ -41,19 +41,29 @@ resource "aws_iam_role_policy" "secretsmanager_for_ecs_task_exec" {
   name  = "secretsmanager-exec"
   role  = aws_iam_role.apiary_task_exec[0].id
 
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": {
-        "Effect": "Allow",
-        "Action": "secretsmanager:GetSecretValue",
-        "Resource": [ 
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = "secretsmanager:GetSecretValue",
+        Resource = (
+        var.external_database_host == "" ?
+        [ 
           "${join("\",\"", concat(data.aws_secretsmanager_secret.docker_registry.*.arn))}",
           "${data.aws_secretsmanager_secret.db_rw_user.arn}",
           "${data.aws_secretsmanager_secret.db_ro_user.arn}",
           "${aws_secretsmanager_secret.apiary_mysql_master_credentials[0].arn}"
+        ] :
+        [ 
+          "${join("\",\"", concat(data.aws_secretsmanager_secret.docker_registry.*.arn))}",
+          "${data.aws_secretsmanager_secret.db_rw_user.arn}",
+          "${data.aws_secretsmanager_secret.db_ro_user.arn}"
         ]
-    }
+      )
+    },
+   ]
+  })
 }
-EOF
-}
+
+

--- a/templates.tf
+++ b/templates.tf
@@ -60,7 +60,7 @@ data "template_file" "hms_readwrite" {
     # Template vars for init container
     init_container_enabled = var.external_database_host == "" ? true : false
     mysql_permissions      = "ALL"
-    mysql_master_cred_arn  = aws_secretsmanager_secret.apiary_mysql_master_credentials[0].arn
+    mysql_master_cred_arn  = var.external_database_host == "" ? aws_secretsmanager_secret.apiary_mysql_master_credentials[0].arn : null
     mysql_user_cred_arn    = data.aws_secretsmanager_secret.db_rw_user.arn
   }
 }
@@ -105,7 +105,7 @@ data "template_file" "hms_readonly" {
     init_container_enabled = var.external_database_host == "" ? true : false
     mysql_permissions      = "SELECT"
     mysql_write_db         = "${var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.endpoint) : var.external_database_host}"
-    mysql_master_cred_arn  = aws_secretsmanager_secret.apiary_mysql_master_credentials[0].arn
+    mysql_master_cred_arn  = var.external_database_host == "" ? aws_secretsmanager_secret.apiary_mysql_master_credentials[0].arn : null
     mysql_user_cred_arn    = data.aws_secretsmanager_secret.db_ro_user.arn
   }
 }


### PR DESCRIPTION
Fixing SM policy & templates for resource `apiary_mysql_master_credentials` when `external_database_host` is in use.