### PR TITLE
Added conditional IAM Roles to S3 bucket policies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [6.17.0] - 2023-05-10
 ### Added
-- New block in every S3 bucket policy called `conditional_consumer_iamroles`. It allows S3 read access to certain IAM Roles based on an `apiary_consumer_condition`.
+- New block in every S3 bucket policy called `conditional_consumer_iamroles`. It allows S3 read access to certain IAM Roles based on an `apiary_customer_condition`.
 
 ## [6.16.0] - 2023-02-10
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.17.0] - 2023-05-10
+### Added
+- New block in every S3 bucket policy called `conditional_consumer_iamroles`. It allows read S3 access to certain IAM Roles based on a `apiary_consumer_condition`.
+
 ## [6.16.0] - 2023-02-10
 ### Changed
 - Update RDS default version from `aurora5.6` to `aurora-mysql5.7`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [6.17.0] - 2023-05-10
 ### Added
-- New block in every S3 bucket policy called `conditional_consumer_iamroles`. It allows read S3 access to certain IAM Roles based on a `apiary_consumer_condition`.
+- New block in every S3 bucket policy called `conditional_consumer_iamroles`. It allows S3 read access to certain IAM Roles based on an `apiary_consumer_condition`.
 
 ## [6.16.0] - 2023-02-10
 ### Changed

--- a/s3.tf
+++ b/s3.tf
@@ -12,18 +12,20 @@ locals {
   bucket_policy_map = {
     for schema in local.schemas_info : schema["schema_name"] => templatefile("${path.module}/templates/apiary-bucket-policy.json", {
       #if apiary_shared_schemas is empty or contains current schema, allow customer accounts to access this bucket.
-      customer_principal    = (length(var.apiary_shared_schemas) == 0 || contains(var.apiary_shared_schemas, schema["schema_name"])) && schema["customer_accounts"] != "" ? join("\",\"", formatlist("arn:aws:iam::%s:root", split(",", schema["customer_accounts"]))) : ""
-      customer_condition    = var.apiary_customer_condition
-      bucket_name           = schema["data_bucket"]
-      encryption            = schema["encryption"]
-      kms_key_arn           = schema["encryption"] == "aws:kms" ? aws_kms_key.apiary_kms[schema["schema_name"]].arn : ""
-      consumer_iamroles     = join("\",\"", var.apiary_consumer_iamroles)
-      producer_iamroles     = replace(lookup(var.apiary_producer_iamroles, schema["schema_name"], ""), ",", "\",\"")
-      deny_iamroles         = join("\",\"", var.apiary_deny_iamroles)
-      deny_iamrole_actions  = join("\",\"", var.apiary_deny_iamrole_actions)
-      client_roles          = replace(lookup(schema, "client_roles", ""), ",", "\",\"")
-      governance_iamroles   = join("\",\"", var.apiary_governance_iamroles)
-      consumer_prefix_roles = lookup(var.apiary_consumer_prefix_iamroles, schema["schema_name"], {})
+      customer_principal            = (length(var.apiary_shared_schemas) == 0 || contains(var.apiary_shared_schemas, schema["schema_name"])) && schema["customer_accounts"] != "" ? join("\",\"", formatlist("arn:aws:iam::%s:root", split(",", schema["customer_accounts"]))) : ""
+      customer_condition            = var.apiary_customer_condition
+      consumer_condition            = var.apiary_consumer_condition
+      bucket_name                   = schema["data_bucket"]
+      encryption                    = schema["encryption"]
+      kms_key_arn                   = schema["encryption"] == "aws:kms" ? aws_kms_key.apiary_kms[schema["schema_name"]].arn : ""
+      consumer_iamroles             = join("\",\"", var.apiary_consumer_iamroles)
+      conditional_consumer_iamroles = join("\",\"", var.apiary_conditional_consumer_iamroles)
+      producer_iamroles             = replace(lookup(var.apiary_producer_iamroles, schema["schema_name"], ""), ",", "\",\"")
+      deny_iamroles                 = join("\",\"", var.apiary_deny_iamroles)
+      deny_iamrole_actions          = join("\",\"", var.apiary_deny_iamrole_actions)
+      client_roles                  = replace(lookup(schema, "client_roles", ""), ",", "\",\"")
+      governance_iamroles           = join("\",\"", var.apiary_governance_iamroles)
+      consumer_prefix_roles         = lookup(var.apiary_consumer_prefix_iamroles, schema["schema_name"], {})
     })
   }
 }

--- a/s3.tf
+++ b/s3.tf
@@ -14,7 +14,6 @@ locals {
       #if apiary_shared_schemas is empty or contains current schema, allow customer accounts to access this bucket.
       customer_principal            = (length(var.apiary_shared_schemas) == 0 || contains(var.apiary_shared_schemas, schema["schema_name"])) && schema["customer_accounts"] != "" ? join("\",\"", formatlist("arn:aws:iam::%s:root", split(",", schema["customer_accounts"]))) : ""
       customer_condition            = var.apiary_customer_condition
-      consumer_condition            = var.apiary_consumer_condition
       bucket_name                   = schema["data_bucket"]
       encryption                    = schema["encryption"]
       kms_key_arn                   = schema["encryption"] == "aws:kms" ? aws_kms_key.apiary_kms[schema["schema_name"]].arn : ""

--- a/templates/apiary-bucket-policy.json
+++ b/templates/apiary-bucket-policy.json
@@ -39,7 +39,11 @@
             "Sid": "Apiary customer account object permissions",
             "Effect": "Allow",
             "Principal": {
+%{if conditional_consumer_iamroles == ""}
                 "AWS": [ "${customer_principal}" ]
+%{else}
+                "AWS": [ "${customer_principal}", "${conditional_consumer_iamroles}" ]
+%{endif}
             },
             "Condition": {
               ${condition}
@@ -107,32 +111,6 @@
               }
             }
         },
-%{endif}
-%{if conditional_consumer_iamroles != "" && consumer_condition != ""}
-%{for condition in split(";",consumer_condition)}
-        {
-            "Sid": "Apiary consumer iamroles based on a condition",
-            "Effect": "Allow",
-            "Principal": "*",
-            "Action": [
-              "s3:GetBucketLocation",
-              "s3:GetObject",
-              "s3:GetObjectAcl",
-              "s3:GetBucketAcl",
-              "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::${bucket_name}",
-                "arn:aws:s3:::${bucket_name}/*"
-            ],
-            "Condition": {
-              "StringLike": {
-                "aws:PrincipalArn": [ "${conditional_consumer_iamroles}" ],
-                ${condition}
-              }
-            }
-        },
-%{endfor}
 %{endif}
 %{if producer_iamroles != ""}
         {

--- a/templates/apiary-bucket-policy.json
+++ b/templates/apiary-bucket-policy.json
@@ -87,7 +87,7 @@
 %{endif}
 %{if consumer_iamroles != ""}
         {
-            "Sid": "Apiary consumer iamrole permissions with full access",
+            "Sid": "Apiary consumer iamrole permissions with unrestricted access",
             "Effect": "Allow",
             "Principal": "*",
             "Action": [

--- a/templates/apiary-bucket-policy.json
+++ b/templates/apiary-bucket-policy.json
@@ -87,7 +87,7 @@
 %{endif}
 %{if consumer_iamroles != ""}
         {
-            "Sid": "Apiary consumer iamrole permissions",
+            "Sid": "Apiary consumer iamrole permissions with full access",
             "Effect": "Allow",
             "Principal": "*",
             "Action": [
@@ -107,6 +107,32 @@
               }
             }
         },
+%{endif}
+%{if conditional_consumer_iamroles != "" && consumer_condition != ""}
+%{for condition in split(";",consumer_condition)}
+        {
+            "Sid": "Apiary consumer iamroles based on a condition",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": [
+              "s3:GetBucketLocation",
+              "s3:GetObject",
+              "s3:GetObjectAcl",
+              "s3:GetBucketAcl",
+              "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${bucket_name}",
+                "arn:aws:s3:::${bucket_name}/*"
+            ],
+            "Condition": {
+              "StringLike": {
+                "aws:PrincipalArn": [ "${conditional_consumer_iamroles}" ],
+                ${condition}
+              }
+            }
+        },
+%{endfor}
 %{endif}
 %{if producer_iamroles != ""}
         {

--- a/variables.tf
+++ b/variables.tf
@@ -181,7 +181,7 @@ variable "apiary_consumer_iamroles" {
 }
 
 variable "apiary_conditional_consumer_iamroles" {
-  description = "AWS IAM roles allowed conditional read access based on apiary_consumer_condition to managed Apiary S3 buckets."
+  description = "AWS IAM roles allowed conditional read access based on apiary_customer_condition to managed Apiary S3 buckets."
   type        = list(string)
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -139,7 +139,13 @@ variable "apiary_customer_accounts" {
 }
 
 variable "apiary_customer_condition" {
-  description = "IAM policy condition applied to customer account s3 object access."
+  description = "IAM policy condition applied to customer account for s3 object access."
+  type        = string
+  default     = ""
+}
+
+variable "apiary_consumer_condition" {
+  description = "IAM policy condition applied to consumer IAM Roles for s3 object access."
   type        = string
   default     = ""
 }
@@ -176,6 +182,12 @@ variable "apiary_assume_roles" {
 
 variable "apiary_consumer_iamroles" {
   description = "AWS IAM roles allowed unrestricted read access to managed Apiary S3 buckets."
+  type        = list(string)
+  default     = []
+}
+
+variable "apiary_conditional_consumer_iamroles" {
+  description = "AWS IAM roles allowed read access based on custom conditions to managed Apiary S3 buckets."
   type        = list(string)
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -144,12 +144,6 @@ variable "apiary_customer_condition" {
   default     = ""
 }
 
-variable "apiary_consumer_condition" {
-  description = "IAM policy condition applied to consumer IAM Roles for s3 object access."
-  type        = string
-  default     = ""
-}
-
 variable "apiary_deny_iamroles" {
   description = "AWS IAM roles denied access to Apiary managed S3 buckets."
   type        = list(string)
@@ -187,7 +181,7 @@ variable "apiary_consumer_iamroles" {
 }
 
 variable "apiary_conditional_consumer_iamroles" {
-  description = "AWS IAM roles allowed read access based on custom conditions to managed Apiary S3 buckets."
+  description = "AWS IAM roles allowed conditional read access based on apiary_consumer_condition to managed Apiary S3 buckets."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description
- New block in every S3 bucket policy called `conditional_consumer_iamroles`. It allows S3 read access to certain IAM Roles based on an `apiary_customer_condition`.

Example:
apiary_customer_condition = StringEquals": {"s3:ExistingObjectTag/shouldBeAccessible": "true" };
conditional_consumer_iamroles = ["arn:aws:iam::1111111111:role/jhon-service"]

John-Service IAM Role will be able to read all the Apiary S3 buckets where their objects are tagged as `shouldBeAccessible=true`

### :link: Related Issues