### PR TITLE
Fix s3 list objects operation for conditional_consumer_iamroles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.18.2] - 2023-06-01
+### Fixed
+- `conditional_consumer_iamroles` were not able to list objects within a buckets.
+
 ## [6.18.1] - 2023-05-30
 ### Changed
 - Added `conditional_consumer_iamroles` in principles even when customer_condition is empty.

--- a/templates/apiary-bucket-policy.json
+++ b/templates/apiary-bucket-policy.json
@@ -7,7 +7,11 @@
             "Sid": "Apiary customer account bucket permissions",
             "Effect": "Allow",
             "Principal": {
+%{if conditional_consumer_iamroles == ""}
                 "AWS": [ "${customer_principal}" ]
+%{else}
+                "AWS": [ "${customer_principal}", "${conditional_consumer_iamroles}" ]
+%{endif}
             },
             "Action": [
                 "s3:GetBucketLocation",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description
- Conditional IAM Roles were not able to list objects for any path of the bucket.

### :link: Related Issues