### PR TITLE
Feature/updating annotations to inline with EGAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.18.3] - 2023-06-16
+### Changed
+- Updated the annotations to include `EGAP` env for `Hive Metastore R/W and R/O` to Datadog UI.
+
 ## [6.18.2] - 2023-06-01
 ### Fixed
 - `conditional_consumer_iamroles` were not able to list objects within a buckets.

--- a/common.tf
+++ b/common.tf
@@ -58,7 +58,7 @@ locals {
   k8s_rw_cpu_limit = (var.hms_rw_cpu / 1024) * 1.25
 
   hms_alias = var.instance_name == "" ? "hms" : "hms-${var.instance_name}"
-  dash = var.instance_name == "analytics" ? "-" : ""
+  dash = var.instance_name != "" ? "-" : ""
 
   ro_ingress_cidr = var.ingress_cidr
   rw_ingress_cidr = length(var.rw_ingress_cidr) == 0 ? var.ingress_cidr : var.rw_ingress_cidr

--- a/common.tf
+++ b/common.tf
@@ -58,6 +58,7 @@ locals {
   k8s_rw_cpu_limit = (var.hms_rw_cpu / 1024) * 1.25
 
   hms_alias = var.instance_name == "" ? "hms" : "hms-${var.instance_name}"
+  dash = var.instance_name == "analytics" ? "-" : ""
 
   ro_ingress_cidr = var.ingress_cidr
   rw_ingress_cidr = length(var.rw_ingress_cidr) == 0 ? var.ingress_cidr : var.rw_ingress_cidr

--- a/common.tf
+++ b/common.tf
@@ -58,7 +58,6 @@ locals {
   k8s_rw_cpu_limit = (var.hms_rw_cpu / 1024) * 1.25
 
   hms_alias = var.instance_name == "" ? "hms" : "hms-${var.instance_name}"
-  dash = var.instance_name != "" ? "-" : ""
 
   ro_ingress_cidr = var.ingress_cidr
   rw_ingress_cidr = length(var.rw_ingress_cidr) == 0 ? var.ingress_cidr : var.rw_ingress_cidr

--- a/k8s-readonly.tf
+++ b/k8s-readonly.tf
@@ -29,9 +29,9 @@ resource "kubernetes_deployment" "apiary_hms_readonly" {
           name = "${local.hms_alias}-readonly"
         }
         annotations = {
-          "ad.datadoghq.com/hms-${var.instance_name}${local.dash}readonly.check_names" = var.datadog_metrics_enabled ? "[\"prometheus\"]" : null
-          "ad.datadoghq.com/hms-${var.instance_name}${local.dash}readonly.init_configs" = var.datadog_metrics_enabled ? "[{}]" : null
-          "ad.datadoghq.com/hms-${var.instance_name}${local.dash}readonly.instances" = var.datadog_metrics_enabled ? "[{ \"prometheus_url\": \"http://%%host%%:${var.datadog_metrics_port}/actuator/prometheus\", \"namespace\": \"hms_readonly\", \"metrics\": [ \"${join("\",\"", var.datadog_metrics_hms_readwrite_readonly)}\" ] , \"type_overrides\": { \"${join("\": \"gauge\",\"", var.datadog_metrics_hms_readwrite_readonly)}\": \"gauge\"} }]"  : null
+          "ad.datadoghq.com/${local.hms_alias}-readonly.check_names" = var.datadog_metrics_enabled ? "[\"prometheus\"]" : null
+          "ad.datadoghq.com/${local.hms_alias}-readonly.init_configs" = var.datadog_metrics_enabled ? "[{}]" : null
+          "ad.datadoghq.com/${local.hms_alias}-readonly.instances" = var.datadog_metrics_enabled ? "[{ \"prometheus_url\": \"http://%%host%%:${var.datadog_metrics_port}/actuator/prometheus\", \"namespace\": \"hms_readonly\", \"metrics\": [ \"${join("\",\"", var.datadog_metrics_hms_readwrite_readonly)}\" ] , \"type_overrides\": { \"${join("\": \"gauge\",\"", var.datadog_metrics_hms_readwrite_readonly)}\": \"gauge\"} }]"  : null
           "iam.amazonaws.com/role" = aws_iam_role.apiary_hms_readonly.name
           "prometheus.io/path"     = "/metrics"
           "prometheus.io/port"     = "8080"

--- a/k8s-readonly.tf
+++ b/k8s-readonly.tf
@@ -29,9 +29,9 @@ resource "kubernetes_deployment" "apiary_hms_readonly" {
           name = "${local.hms_alias}-readonly"
         }
         annotations = { //hms--readonly
-          "ad.datadoghq.com/hms-${var.instance_name}readonly.check_names" = var.datadog_metrics_enabled ? "[\"prometheus\"]" : null
-          "ad.datadoghq.com/hms-${var.instance_name}readonly.init_configs" = var.datadog_metrics_enabled ? "[{}]" : null
-          "ad.datadoghq.com/hms-${var.instance_name}readonly.instances" = var.datadog_metrics_enabled ? "[{ \"prometheus_url\": \"http://%%host%%:${var.datadog_metrics_port}/actuator/prometheus\", \"namespace\": \"hms_readonly\", \"metrics\": [ \"${join("\",\"", var.datadog_metrics_hms_readwrite_readonly)}\" ] , \"type_overrides\": { \"${join("\": \"gauge\",\"", var.datadog_metrics_hms_readwrite_readonly)}\": \"gauge\"} }]"  : null
+          "ad.datadoghq.com/hms-${var.instance_name}${local.dash}readonly.check_names" = var.datadog_metrics_enabled ? "[\"prometheus\"]" : null
+          "ad.datadoghq.com/hms-${var.instance_name}${local.dash}readonly.init_configs" = var.datadog_metrics_enabled ? "[{}]" : null
+          "ad.datadoghq.com/hms-${var.instance_name}${local.dash}readonly.instances" = var.datadog_metrics_enabled ? "[{ \"prometheus_url\": \"http://%%host%%:${var.datadog_metrics_port}/actuator/prometheus\", \"namespace\": \"hms_readonly\", \"metrics\": [ \"${join("\",\"", var.datadog_metrics_hms_readwrite_readonly)}\" ] , \"type_overrides\": { \"${join("\": \"gauge\",\"", var.datadog_metrics_hms_readwrite_readonly)}\": \"gauge\"} }]"  : null
           "iam.amazonaws.com/role" = aws_iam_role.apiary_hms_readonly.name
           "prometheus.io/path"     = "/metrics"
           "prometheus.io/port"     = "8080"

--- a/k8s-readonly.tf
+++ b/k8s-readonly.tf
@@ -28,10 +28,10 @@ resource "kubernetes_deployment" "apiary_hms_readonly" {
         labels = {
           name = "${local.hms_alias}-readonly"
         }
-        annotations = {
-          "ad.datadoghq.com/hms-${var.instance_name}-readonly.check_names" = var.datadog_metrics_enabled ? "[\"prometheus\"]" : null
-          "ad.datadoghq.com/hms-${var.instance_name}-readonly.init_configs" = var.datadog_metrics_enabled ? "[{}]" : null
-          "ad.datadoghq.com/hms-${var.instance_name}-readonly.instances" = var.datadog_metrics_enabled ? "[{ \"prometheus_url\": \"http://%%host%%:${var.datadog_metrics_port}/actuator/prometheus\", \"namespace\": \"hms_readonly\", \"metrics\": [ \"${join("\",\"", var.datadog_metrics_hms_readwrite_readonly)}\" ] , \"type_overrides\": { \"${join("\": \"gauge\",\"", var.datadog_metrics_hms_readwrite_readonly)}\": \"gauge\"} }]"  : null
+        annotations = { //hms--readonly
+          "ad.datadoghq.com/hms-${var.instance_name}readonly.check_names" = var.datadog_metrics_enabled ? "[\"prometheus\"]" : null
+          "ad.datadoghq.com/hms-${var.instance_name}readonly.init_configs" = var.datadog_metrics_enabled ? "[{}]" : null
+          "ad.datadoghq.com/hms-${var.instance_name}readonly.instances" = var.datadog_metrics_enabled ? "[{ \"prometheus_url\": \"http://%%host%%:${var.datadog_metrics_port}/actuator/prometheus\", \"namespace\": \"hms_readonly\", \"metrics\": [ \"${join("\",\"", var.datadog_metrics_hms_readwrite_readonly)}\" ] , \"type_overrides\": { \"${join("\": \"gauge\",\"", var.datadog_metrics_hms_readwrite_readonly)}\": \"gauge\"} }]"  : null
           "iam.amazonaws.com/role" = aws_iam_role.apiary_hms_readonly.name
           "prometheus.io/path"     = "/metrics"
           "prometheus.io/port"     = "8080"

--- a/k8s-readonly.tf
+++ b/k8s-readonly.tf
@@ -28,7 +28,7 @@ resource "kubernetes_deployment" "apiary_hms_readonly" {
         labels = {
           name = "${local.hms_alias}-readonly"
         }
-        annotations = { //hms--readonly
+        annotations = {
           "ad.datadoghq.com/hms-${var.instance_name}${local.dash}readonly.check_names" = var.datadog_metrics_enabled ? "[\"prometheus\"]" : null
           "ad.datadoghq.com/hms-${var.instance_name}${local.dash}readonly.init_configs" = var.datadog_metrics_enabled ? "[{}]" : null
           "ad.datadoghq.com/hms-${var.instance_name}${local.dash}readonly.instances" = var.datadog_metrics_enabled ? "[{ \"prometheus_url\": \"http://%%host%%:${var.datadog_metrics_port}/actuator/prometheus\", \"namespace\": \"hms_readonly\", \"metrics\": [ \"${join("\",\"", var.datadog_metrics_hms_readwrite_readonly)}\" ] , \"type_overrides\": { \"${join("\": \"gauge\",\"", var.datadog_metrics_hms_readwrite_readonly)}\": \"gauge\"} }]"  : null

--- a/k8s-readonly.tf
+++ b/k8s-readonly.tf
@@ -29,9 +29,9 @@ resource "kubernetes_deployment" "apiary_hms_readonly" {
           name = "${local.hms_alias}-readonly"
         }
         annotations = {
-          "ad.datadoghq.com/hms-readonly.check_names" = var.datadog_metrics_enabled ? "[\"prometheus\"]" : null
-          "ad.datadoghq.com/hms-readonly.init_configs" = var.datadog_metrics_enabled ? "[{}]" : null
-          "ad.datadoghq.com/hms-readonly.instances" = var.datadog_metrics_enabled ? "[{ \"prometheus_url\": \"http://%%host%%:${var.datadog_metrics_port}/actuator/prometheus\", \"namespace\": \"hms_readonly\", \"metrics\": [ \"${join("\",\"", var.datadog_metrics_hms_readwrite_readonly)}\" ] , \"type_overrides\": { \"${join("\": \"gauge\",\"", var.datadog_metrics_hms_readwrite_readonly)}\": \"gauge\"} }]"  : null
+          "ad.datadoghq.com/hms-${var.instance_name}-readonly.check_names" = var.datadog_metrics_enabled ? "[\"prometheus\"]" : null
+          "ad.datadoghq.com/hms-${var.instance_name}-readonly.init_configs" = var.datadog_metrics_enabled ? "[{}]" : null
+          "ad.datadoghq.com/hms-${var.instance_name}-readonly.instances" = var.datadog_metrics_enabled ? "[{ \"prometheus_url\": \"http://%%host%%:${var.datadog_metrics_port}/actuator/prometheus\", \"namespace\": \"hms_readonly\", \"metrics\": [ \"${join("\",\"", var.datadog_metrics_hms_readwrite_readonly)}\" ] , \"type_overrides\": { \"${join("\": \"gauge\",\"", var.datadog_metrics_hms_readwrite_readonly)}\": \"gauge\"} }]"  : null
           "iam.amazonaws.com/role" = aws_iam_role.apiary_hms_readonly.name
           "prometheus.io/path"     = "/metrics"
           "prometheus.io/port"     = "8080"

--- a/k8s-readwrite.tf
+++ b/k8s-readwrite.tf
@@ -29,9 +29,9 @@ resource "kubernetes_deployment" "apiary_hms_readwrite" {
           name = "${local.hms_alias}-readwrite"
         }
         annotations = {
-          "ad.datadoghq.com/hms-${var.instance_name}${local.dash}readwrite.check_names" = var.datadog_metrics_enabled ? "[\"prometheus\"]" : null
-          "ad.datadoghq.com/hms-${var.instance_name}${local.dash}readwrite.init_configs" = var.datadog_metrics_enabled ? "[{}]" : null
-          "ad.datadoghq.com/hms-${var.instance_name}${local.dash}readwrite.instances" = var.datadog_metrics_enabled ? "[{ \"prometheus_url\": \"http://%%host%%:${var.datadog_metrics_port}/actuator/prometheus\", \"namespace\": \"hms_readwrite\", \"metrics\": [ \"${join("\",\"", var.datadog_metrics_hms_readwrite_readonly)}\" ] , \"type_overrides\": { \"${join("\": \"gauge\",\"", var.datadog_metrics_hms_readwrite_readonly)}\": \"gauge\"} }]" : null
+          "ad.datadoghq.com/${local.hms_alias}-readwrite.check_names" = var.datadog_metrics_enabled ? "[\"prometheus\"]" : null
+          "ad.datadoghq.com/${local.hms_alias}-readwrite.init_configs" = var.datadog_metrics_enabled ? "[{}]" : null
+          "ad.datadoghq.com/${local.hms_alias}-readwrite.instances" = var.datadog_metrics_enabled ? "[{ \"prometheus_url\": \"http://%%host%%:${var.datadog_metrics_port}/actuator/prometheus\", \"namespace\": \"hms_readwrite\", \"metrics\": [ \"${join("\",\"", var.datadog_metrics_hms_readwrite_readonly)}\" ] , \"type_overrides\": { \"${join("\": \"gauge\",\"", var.datadog_metrics_hms_readwrite_readonly)}\": \"gauge\"} }]" : null
           "iam.amazonaws.com/role" = aws_iam_role.apiary_hms_readwrite.name
           "prometheus.io/path"     = "/metrics"
           "prometheus.io/port"     = "8080"

--- a/k8s-readwrite.tf
+++ b/k8s-readwrite.tf
@@ -27,7 +27,7 @@ resource "kubernetes_deployment" "apiary_hms_readwrite" {
       metadata {
         labels = {
           name = "${local.hms_alias}-readwrite"
-        } // hms-analytics-readwrite or hms-readwrite and ${local.hms_alias} = hms-
+        }
         annotations = {
           "ad.datadoghq.com/hms-${var.instance_name}${local.dash}readwrite.check_names" = var.datadog_metrics_enabled ? "[\"prometheus\"]" : null
           "ad.datadoghq.com/hms-${var.instance_name}${local.dash}readwrite.init_configs" = var.datadog_metrics_enabled ? "[{}]" : null

--- a/k8s-readwrite.tf
+++ b/k8s-readwrite.tf
@@ -27,11 +27,11 @@ resource "kubernetes_deployment" "apiary_hms_readwrite" {
       metadata {
         labels = {
           name = "${local.hms_alias}-readwrite"
-        }
+        } // hms-analytics-readwrite or hms-readwrite and ${local.hms_alias} = hms-
         annotations = {
-          "ad.datadoghq.com/hms-readwrite.check_names" = var.datadog_metrics_enabled ? "[\"prometheus\"]" : null
-          "ad.datadoghq.com/hms-readwrite.init_configs" = var.datadog_metrics_enabled ? "[{}]" : null
-          "ad.datadoghq.com/hms-readwrite.instances" = var.datadog_metrics_enabled ? "[{ \"prometheus_url\": \"http://%%host%%:${var.datadog_metrics_port}/actuator/prometheus\", \"namespace\": \"hms_readwrite\", \"metrics\": [ \"${join("\",\"", var.datadog_metrics_hms_readwrite_readonly)}\" ] , \"type_overrides\": { \"${join("\": \"gauge\",\"", var.datadog_metrics_hms_readwrite_readonly)}\": \"gauge\"} }]" : null
+          "ad.datadoghq.com/hms-${var.instance_name}-readwrite.check_names" = var.datadog_metrics_enabled ? "[\"prometheus\"]" : null
+          "ad.datadoghq.com/hms-${var.instance_name}-readwrite.init_configs" = var.datadog_metrics_enabled ? "[{}]" : null
+          "ad.datadoghq.com/hms-${var.instance_name}-readwrite.instances" = var.datadog_metrics_enabled ? "[{ \"prometheus_url\": \"http://%%host%%:${var.datadog_metrics_port}/actuator/prometheus\", \"namespace\": \"hms_readwrite\", \"metrics\": [ \"${join("\",\"", var.datadog_metrics_hms_readwrite_readonly)}\" ] , \"type_overrides\": { \"${join("\": \"gauge\",\"", var.datadog_metrics_hms_readwrite_readonly)}\": \"gauge\"} }]" : null
           "iam.amazonaws.com/role" = aws_iam_role.apiary_hms_readwrite.name
           "prometheus.io/path"     = "/metrics"
           "prometheus.io/port"     = "8080"

--- a/k8s-readwrite.tf
+++ b/k8s-readwrite.tf
@@ -29,9 +29,9 @@ resource "kubernetes_deployment" "apiary_hms_readwrite" {
           name = "${local.hms_alias}-readwrite"
         } // hms-analytics-readwrite or hms-readwrite and ${local.hms_alias} = hms-
         annotations = {
-          "ad.datadoghq.com/hms-${var.instance_name}-readwrite.check_names" = var.datadog_metrics_enabled ? "[\"prometheus\"]" : null
-          "ad.datadoghq.com/hms-${var.instance_name}-readwrite.init_configs" = var.datadog_metrics_enabled ? "[{}]" : null
-          "ad.datadoghq.com/hms-${var.instance_name}-readwrite.instances" = var.datadog_metrics_enabled ? "[{ \"prometheus_url\": \"http://%%host%%:${var.datadog_metrics_port}/actuator/prometheus\", \"namespace\": \"hms_readwrite\", \"metrics\": [ \"${join("\",\"", var.datadog_metrics_hms_readwrite_readonly)}\" ] , \"type_overrides\": { \"${join("\": \"gauge\",\"", var.datadog_metrics_hms_readwrite_readonly)}\": \"gauge\"} }]" : null
+          "ad.datadoghq.com/hms-${var.instance_name}readwrite.check_names" = var.datadog_metrics_enabled ? "[\"prometheus\"]" : null
+          "ad.datadoghq.com/hms-${var.instance_name}readwrite.init_configs" = var.datadog_metrics_enabled ? "[{}]" : null
+          "ad.datadoghq.com/hms-${var.instance_name}readwrite.instances" = var.datadog_metrics_enabled ? "[{ \"prometheus_url\": \"http://%%host%%:${var.datadog_metrics_port}/actuator/prometheus\", \"namespace\": \"hms_readwrite\", \"metrics\": [ \"${join("\",\"", var.datadog_metrics_hms_readwrite_readonly)}\" ] , \"type_overrides\": { \"${join("\": \"gauge\",\"", var.datadog_metrics_hms_readwrite_readonly)}\": \"gauge\"} }]" : null
           "iam.amazonaws.com/role" = aws_iam_role.apiary_hms_readwrite.name
           "prometheus.io/path"     = "/metrics"
           "prometheus.io/port"     = "8080"

--- a/k8s-readwrite.tf
+++ b/k8s-readwrite.tf
@@ -29,9 +29,9 @@ resource "kubernetes_deployment" "apiary_hms_readwrite" {
           name = "${local.hms_alias}-readwrite"
         } // hms-analytics-readwrite or hms-readwrite and ${local.hms_alias} = hms-
         annotations = {
-          "ad.datadoghq.com/hms-${var.instance_name}readwrite.check_names" = var.datadog_metrics_enabled ? "[\"prometheus\"]" : null
-          "ad.datadoghq.com/hms-${var.instance_name}readwrite.init_configs" = var.datadog_metrics_enabled ? "[{}]" : null
-          "ad.datadoghq.com/hms-${var.instance_name}readwrite.instances" = var.datadog_metrics_enabled ? "[{ \"prometheus_url\": \"http://%%host%%:${var.datadog_metrics_port}/actuator/prometheus\", \"namespace\": \"hms_readwrite\", \"metrics\": [ \"${join("\",\"", var.datadog_metrics_hms_readwrite_readonly)}\" ] , \"type_overrides\": { \"${join("\": \"gauge\",\"", var.datadog_metrics_hms_readwrite_readonly)}\": \"gauge\"} }]" : null
+          "ad.datadoghq.com/hms-${var.instance_name}${local.dash}readwrite.check_names" = var.datadog_metrics_enabled ? "[\"prometheus\"]" : null
+          "ad.datadoghq.com/hms-${var.instance_name}${local.dash}readwrite.init_configs" = var.datadog_metrics_enabled ? "[{}]" : null
+          "ad.datadoghq.com/hms-${var.instance_name}${local.dash}readwrite.instances" = var.datadog_metrics_enabled ? "[{ \"prometheus_url\": \"http://%%host%%:${var.datadog_metrics_port}/actuator/prometheus\", \"namespace\": \"hms_readwrite\", \"metrics\": [ \"${join("\",\"", var.datadog_metrics_hms_readwrite_readonly)}\" ] , \"type_overrides\": { \"${join("\": \"gauge\",\"", var.datadog_metrics_hms_readwrite_readonly)}\": \"gauge\"} }]" : null
           "iam.amazonaws.com/role" = aws_iam_role.apiary_hms_readwrite.name
           "prometheus.io/path"     = "/metrics"
           "prometheus.io/port"     = "8080"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description Updated the annotations to include `EGAP` env for `Hive Metastore R/W and R/O` to Datadog UI.


### :link: Related Issues