### PR TITLE
feature: remove bucket acl as it's disabled when object_ownership set to `BucketOwnerEnforced`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Changed `k8s` API to work with provider 2.x
 - Changed Terraform `map` to `tomap` to make it work with newer TF provider(The map function was deprecated in Terraform v0.12 and is no longer available).
 - Upgrade AWS provider to `4.x`.
+- Removed bucket `ACL` as when bucket `object_ownership` set to `BucketOwnerEnforced`, it's disabled `ACL`.
   
 ## [6.19.1] - 2023-08-25
 ### Fixed

--- a/s3-other.tf
+++ b/s3-other.tf
@@ -7,7 +7,6 @@
 resource "aws_s3_bucket" "apiary_inventory_bucket" {
   count  = var.s3_enable_inventory == true ? 1 : 0
   bucket = local.s3_inventory_bucket
-  acl    = "private"
   tags   = merge(tomap({"Name"="${local.s3_inventory_bucket}"}), "${var.apiary_tags}")
   policy = <<EOF
 {
@@ -91,13 +90,6 @@ resource "aws_s3_bucket_ownership_controls" "apiary_inventory_bucket" {
   rule {
     object_ownership = "BucketOwnerEnforced"
   }
-}
-
-resource "aws_s3_bucket_acl" "apiary_inventory_bucket" {
-  count  = var.s3_enable_inventory == true ? 1 : 0
-  depends_on = [aws_s3_bucket_ownership_controls.apiary_inventory_bucket[0]]
-  bucket = aws_s3_bucket.apiary_inventory_bucket[0].id
-  acl    = "private"
 }
 
 resource "aws_s3_bucket" "apiary_managed_logs_bucket" {

--- a/s3.tf
+++ b/s3.tf
@@ -122,14 +122,6 @@ resource "aws_s3_bucket_ownership_controls" "apiary_bucket" {
   }
 }
 
-resource "aws_s3_bucket_acl" "apiary_data_bucket" {
-  for_each = {
-    for schema in local.schemas_info : "${schema["schema_name"]}" => schema
-  }
-  bucket = aws_s3_bucket.apiary_data_bucket[each.key].id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_notification" "data_events" {
   for_each = var.enable_data_events ? {
     for schema in local.schemas_info : "${schema["schema_name"]}" => schema if lookup(schema, "enable_data_events_sqs", "0") == "0"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description


### :link: Related Issues