### PR TITLE
fix: Enable Datadog filtering for HMS metrics on ECS with Apiary tags

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -9,6 +9,8 @@ locals {
   apiary_bucket_prefix             = "${local.instance_alias}-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
   apiary_assume_role_bucket_prefix = [for assumerole in var.apiary_assume_roles : "${local.instance_alias}-${data.aws_caller_identity.current.account_id}-${lookup(assumerole, "allow_cross_region_access", false) ? "*" : data.aws_region.current.name}"]
   enable_route53_records           = var.apiary_domain_name == "" ? false : true
+
+  datadog_tags = join(" ", formatlist("%s:%s", keys(var.apiary_tags), values(var.apiary_tags)))
   #
   # Create a new list of maps with some extra attributes needed later
   #

--- a/templates.tf
+++ b/templates.tf
@@ -68,6 +68,7 @@ locals{
     metrics_port          = var.datadog_metrics_port
     datadog_agent_version = var.datadog_agent_version
     datadog_agent_enabled = var.datadog_agent_enabled
+    datadog_tags          = local.datadog_tags
   })
 
   hms_readonly_template = templatefile("${path.module}/templates/apiary-hms-readonly.json", {
@@ -118,5 +119,6 @@ locals{
     wd_instance_type      = var.hms_instance_type
     metrics_port          = var.datadog_metrics_port
     datadog_agent_version = var.datadog_agent_version
+    datadog_tags          = local.datadog_tags
   })
 }

--- a/templates/apiary-hms-readonly.json
+++ b/templates/apiary-hms-readonly.json
@@ -205,6 +205,10 @@
       {
         "name": "ECS_FARGATE",
         "value": "true"
+      },
+      {
+        "name": "DD_TAGS",
+        "value": "${datadog_tags}"
       }
     ]
   }

--- a/templates/apiary-hms-readwrite.json
+++ b/templates/apiary-hms-readwrite.json
@@ -257,6 +257,10 @@
      {
        "name": "ECS_FARGATE",
        "value": "true"
+     },
+     {
+      "name": "DD_TAGS",
+      "value": "${datadog_tags}"
      }
    ]
  }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description
This pull request introduces Apiary tags to the Datadog agent for ECS. Apiary tags are a method for attaching additional metadata to metrics, enabling them to be filtered and grouped more effectively within Datadog.

### :link: Related Issues