### PR TITLE
fix: added datadog provider source to avoid conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.1.2] - 2024-04-03
+### Fixed
+- Added provider source for `datadog`.
+
 ## [7.1.1] - 2024-04-03
 ### Fixed
 - Renamed variable from `common_producer_iamroles` to `apiary_common_producer_iamroles` to make the name consistent.

--- a/s3-other.tf
+++ b/s3-other.tf
@@ -7,7 +7,7 @@
 resource "aws_s3_bucket" "apiary_inventory_bucket" {
   count  = var.s3_enable_inventory == true ? 1 : 0
   bucket = local.s3_inventory_bucket
-  tags   = merge(tomap({"Name"="${local.s3_inventory_bucket}"}), "${var.apiary_tags}")
+  tags   = merge(tomap({"Name"="${local.s3_inventory_bucket}"}), var.apiary_tags)
   policy = <<EOF
 {
   "Version":"2012-10-17",

--- a/version.tf
+++ b/version.tf
@@ -15,5 +15,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.0"
     }
+    datadog = {
+      source = "DataDog/datadog"
+      version = "3.25.0"
+    }
   }
 }

--- a/vpc-endpoint-service.tf
+++ b/vpc-endpoint-service.tf
@@ -9,7 +9,7 @@ resource "aws_vpc_endpoint_service" "hms_readonly" {
   network_load_balancer_arns = compact(concat(aws_lb.apiary_hms_ro_lb.*.arn, data.aws_lb.k8s_hms_ro_lb.*.arn))
   acceptance_required        = false
   allowed_principals         = formatlist("arn:aws:iam::%s:root", var.apiary_customer_accounts)
-  tags                       = merge(tomap({"Name"="${local.instance_alias}-hms-readonly"}), "${var.apiary_tags}")
+  tags                       = merge(tomap({"Name"="${local.instance_alias}-hms-readonly"}), var.apiary_tags)
 }
 
 resource "aws_vpc_endpoint_connection_notification" "hms_readonly" {
@@ -24,7 +24,7 @@ resource "aws_vpc_endpoint_service" "hms_readwrite" {
   network_load_balancer_arns = compact(concat(aws_lb.apiary_hms_rw_lb.*.arn, data.aws_lb.k8s_hms_rw_lb.*.arn))
   acceptance_required        = false
   allowed_principals         = distinct(compact(concat(local.assume_allowed_principals, local.producer_allowed_principals)))
-  tags                       = merge(tomap({"Name"="${local.instance_alias}-hms-readwrite"}), "${var.apiary_tags}")
+  tags                       = merge(tomap({"Name"="${local.instance_alias}-hms-readwrite"}), var.apiary_tags)
 }
 
 resource "aws_vpc_endpoint_connection_notification" "hms_readwrite" {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description

11:54:41		Error: Failed to query available provider packages
11:54:41		
11:54:41		Could not retrieve the list of available versions for provider
11:54:41		hashicorp/datadog: provider registry registry.terraform.io does not have a
11:54:41		provider named registry.terraform.io/hashicorp/datadog
11:54:41		
11:54:41		Did you intend to use datadog/datadog? If so, you must specify that source
11:54:41		address in each module which requires that provider. To see which modules are
11:54:41		currently depending on hashicorp/datadog, run the following command:
11:54:41		    terraform providers
### :link: Related Issues