### PR TITLE
Changed hms-housekeeper heapsize since it is low memory container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.1.9] - 2024-06-20
+### Fixed
+- Housekeeper deployment should not use common `HADOOP_HEAPSIZE` variable since it is a low memory container.
+
 ## [7.1.8] - 2024-06-19
 ### Added
 - `hms_housekeeper_additional_environment_variables` variable to provide ability to add a list of environment variables in `hms-housekeeper` deployment.

--- a/k8s-housekeeper.tf
+++ b/k8s-housekeeper.tf
@@ -111,7 +111,7 @@ resource "kubernetes_deployment_v1" "apiary_hms_housekeeper" {
           }
           env {
             name  = "HADOOP_HEAPSIZE"
-            value = local.hms_rw_heapsize
+            value = "1740"
           }
           env {
             name  = "AWS_REGION"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description
If you would like to set hms-readwrite to 24Gib, hms-housekeeper `HADOOP_HEAPSIZE` will also be set to 24Gib, however its kubernetes requests and limits are strictly set to 2Gib since it is a low memory container.

### :link: Related Issues