### PR TITLE
Added capability to choose Connection Pooling driver and specify it's configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [7.10.0] - 2024-06-26
+## [7.2.0] - 2024-06-26
 ### Added
 - Added `hms_ro_datanucleus_connection_pooling_type`, `hms_rw_datanucleus_connection_pooling_type`, `hms_ro_datanucleus_connection_pool_config`, `hms_rw_datanucleus_connection_pool_config`, `hms_housekeeper_db_connection_pool_size` variables to allow specifying the pooling driver and its config
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.10.0] - 2024-06-26
+### Added
+- Added `hms_ro_datanucleus_connection_pooling_type`, `hms_rw_datanucleus_connection_pooling_type`, `hms_ro_datanucleus_connection_pool_config`, `hms_rw_datanucleus_connection_pool_config`, `hms_housekeeper_db_connection_pool_size` variables to allow specifying the pooling driver and its config
+
 ## [7.1.9] - 2024-06-20
 ### Fixed
 - Housekeeper deployment should not use common `HADOOP_HEAPSIZE` variable since it is a low memory container.

--- a/k8s-housekeeper.tf
+++ b/k8s-housekeeper.tf
@@ -133,6 +133,17 @@ resource "kubernetes_deployment_v1" "apiary_hms_housekeeper" {
             name  = "ENABLE_HIVE_LOCK_HOUSE_KEEPER"
             value = var.enable_hms_housekeeper ? "true" : ""
           }
+
+          env {
+            name  = "DATANUCLEUS_CONNECTION_POOLING_TYPE"
+            value = var.hms_rw_datanucleus_connection_pooling_type
+          }
+
+          env {
+            name  = "DATANUCLEUS_CONNECTION_POOL_MAX_POOLSIZE"
+            value = var.hms_housekeeper_db_connection_pool_size
+          }
+
           dynamic "env" {
             for_each = var.hms_housekeeper_additional_environment_variables
 

--- a/k8s-readonly.tf
+++ b/k8s-readonly.tf
@@ -175,10 +175,6 @@ resource "kubernetes_deployment_v1" "apiary_hms_readonly" {
             value = local.hms_ro_maxthreads
           }
           env {
-            name  = "MYSQL_CONNECTION_POOL_SIZE"
-            value = var.hms_ro_db_connection_pool_size
-          }
-          env {
             name  = "HMS_AUTOGATHER_STATS"
             value = "false"
           }
@@ -186,9 +182,29 @@ resource "kubernetes_deployment_v1" "apiary_hms_readonly" {
             name  = "LIMIT_PARTITION_REQUEST_NUMBER"
             value = var.hms_ro_request_partition_limit == "" ? "" : var.hms_ro_request_partition_limit
           }
+          env {
+            name  = "DATANUCLEUS_CONNECTION_POOLING_TYPE"
+            value = var.hms_ro_datanucleus_connection_pooling_type
+          }
+          env {
+            name  = "DATANUCLEUS_CONNECTION_POOL_MAX_POOLSIZE"
+            value = var.hms_ro_db_connection_pool_size
+          }
+
           dynamic "env" {
             for_each = var.hms_additional_environment_variables
 
+            content {
+              name  = env.key
+              value = env.value
+            }
+          }
+
+          dynamic "env" {
+            for_each = {
+              for k, v in var.hms_ro_datanucleus_connection_pool_config :
+              k => v if v != null
+            }
             content {
               name  = env.key
               value = env.value

--- a/k8s-readonly.tf
+++ b/k8s-readonly.tf
@@ -201,10 +201,8 @@ resource "kubernetes_deployment_v1" "apiary_hms_readonly" {
           }
 
           dynamic "env" {
-            for_each = {
-              for k, v in var.hms_ro_datanucleus_connection_pool_config :
-              k => v if v != null
-            }
+            for_each = var.hms_ro_datanucleus_connection_pool_config
+
             content {
               name  = env.key
               value = env.value

--- a/k8s-readwrite.tf
+++ b/k8s-readwrite.tf
@@ -241,10 +241,8 @@ resource "kubernetes_deployment_v1" "apiary_hms_readwrite" {
           }
 
           dynamic "env" {
-            for_each = {
-              for k, v in var.hms_rw_datanucleus_connection_pool_config :
-              k => v if v != null
-            }
+            for_each = var.hms_rw_datanucleus_connection_pool_config
+
             content {
               name  = env.key
               value = env.value

--- a/k8s-readwrite.tf
+++ b/k8s-readwrite.tf
@@ -215,10 +215,6 @@ resource "kubernetes_deployment_v1" "apiary_hms_readwrite" {
             value = var.disallow_incompatible_col_type_changes
           }
           env {
-            name  = "MYSQL_CONNECTION_POOL_SIZE"
-            value = var.hms_rw_db_connection_pool_size
-          }
-          env {
             name  = "HMS_AUTOGATHER_STATS"
             value = var.hms_autogather_stats
           }
@@ -226,9 +222,29 @@ resource "kubernetes_deployment_v1" "apiary_hms_readwrite" {
             name  = "LIMIT_PARTITION_REQUEST_NUMBER"
             value = var.hms_rw_request_partition_limit == "" ? "" : var.hms_rw_request_partition_limit
           }
+          env {
+            name  = "DATANUCLEUS_CONNECTION_POOLING_TYPE"
+            value = var.hms_rw_datanucleus_connection_pooling_type
+          }
+          env {
+            name  = "DATANUCLEUS_CONNECTION_POOL_MAX_POOLSIZE"
+            value = var.hms_rw_db_connection_pool_size
+          }
+          
           dynamic "env" {
             for_each = var.hms_additional_environment_variables
 
+            content {
+              name  = env.key
+              value = env.value
+            }
+          }
+
+          dynamic "env" {
+            for_each = {
+              for k, v in var.hms_rw_datanucleus_connection_pool_config :
+              k => v if v != null
+            }
             content {
               name  = env.key
               value = env.value

--- a/variables.tf
+++ b/variables.tf
@@ -661,15 +661,21 @@ variable "hms_autogather_stats" {
 }
 
 variable "hms_ro_db_connection_pool_size" {
-  description = "Read-only Hive metastore setting for size of the MySQL connection pool. Default is 10."
+  description = "Read-only Hive metastore setting for max size of the MySQL connection pool. Default is 10."
   type        = number
   default     = 10
 }
 
 variable "hms_rw_db_connection_pool_size" {
-  description = "Read-write Hive metastore setting for size of the MySQL connection pool. Default is 10."
+  description = "Read-write Hive metastore setting for max size of the MySQL connection pool. Default is 10."
   type        = number
   default     = 10
+}
+
+variable "hms_housekeeper_db_connection_pool_size" {
+  description = "HMS Housekeeper setting for max size of the MySQL connection pool. Default is 5."
+  type        = number
+  default     = 5
 }
 
 variable "db_enable_performance_insights" {
@@ -756,4 +762,28 @@ variable "apiary_common_producer_iamroles" {
   description = "AWS IAM roles allowed read-write access to managed Apiary S3 buckets."
   type        = list(string)
   default     = []
+}
+
+variable "hms_ro_datanucleus_connection_pooling_type" {
+  description = "The Datanucleus connection pool type: Valid types are BoneCP, HikariCP, c3p0, dbcp, dbcp2"
+  type    = string
+  default = "HikariCP"
+}
+
+variable "hms_rw_datanucleus_connection_pooling_type" {
+  description = "The Datanucleus connection pool type: Valid types are BoneCP, HikariCP, c3p0, dbcp, dbcp2"
+  type    = string
+  default = "HikariCP"
+}
+
+variable "hms_ro_datanucleus_connection_pool_config" {
+  description = "A map of env vars supported by Apiary docker image that can configure the chosen Datanucleus connection pool"
+  type = map(any)
+  default = {}
+}
+
+variable "hms_rw_datanucleus_connection_pool_config" {
+  description = "A map of env vars supported by Apiary docker image that can configure the chosen Datanucleus connection pool"  
+  type = map(any)
+  default = {}
 }


### PR DESCRIPTION
Added `hms_ro_datanucleus_connection_pooling_type`, `hms_rw_datanucleus_connection_pooling_type`, `hms_ro_datanucleus_connection_pool_config`, `hms_rw_datanucleus_connection_pool_config`, `hms_housekeeper_db_connection_pool_size` variables to allow specifying the pooling driver and its config

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description


### :link: Related Issues