### PR TITLE
fix: update cronjob api to v1 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.2.3] - 2024-08-14
+### Fixed
+- Changed terraform cron job api from `kubernetes_cron_job` to `kubernetes_cron_job_v1` to compatible with eks v1.25 and later.
+
 ## [7.2.2] - 2024-07-24
 ### Fixed
 - [Issue 266](https://github.com/ExpediaGroup/apiary-data-lake/issues/266) Apiary bucket policies over-enforce encryption

--- a/k8s-cronjobs.tf
+++ b/k8s-cronjobs.tf
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  */
 
-resource "kubernetes_cron_job" "apiary_inventory" {
+resource "kubernetes_cron_job_v1" "apiary_inventory" {
   count = (var.s3_enable_inventory && var.hms_instance_type == "k8s") ? 1 : 0
   metadata {
     name      = "${local.instance_alias}-s3-inventory"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description
### Fixed
- Changed terraform cron job api from `kubernetes_cron_job` to `kubernetes_cron_job_v1` to compatible with eks v1.25 and later.

### :link: Related Issues