### PR TITLE
fix: fixing s3 inventory service account secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.3.1] - 2024-08-26
+### Fixed
+- Fixed incorrect `s3-inventory` service account secret binding.
+
 ## [7.3.0] - 2024-08-20
 ### Added
 - If apiary_managed_schemas has `deny_global_write_access` enabled, only `producer_roles` will be able to write in the specified schema.

--- a/k8s-service-accounts.tf
+++ b/k8s-service-accounts.tf
@@ -65,10 +65,10 @@ resource "kubernetes_service_account_v1" "s3_inventory" {
 
 resource "kubernetes_secret_v1" "s3_inventory" {
   metadata {
-    name        = "${local.hms_alias}-s3-inventory"
+    name        = "${local.instance_alias}-s3-inventory"
     namespace   = var.metastore_namespace
     annotations = {
-      "kubernetes.io/service-account.name"      ="${local.hms_alias}-s3-inventory"
+      "kubernetes.io/service-account.name"      ="${local.instance_alias}-s3-inventory"
       "kubernetes.io/service-account.namespace" = var.metastore_namespace
     }
   }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description

### Fixed
- Fixed incorrect `s3-inventory` service account secret binding.
### :link: Related Issues