### PR TITLE
fix: add condition on create apiary db parameter group resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.3.8] - 2024-09-11
+### Fixed
+- Enable `apiary_db_para_group` only when `external_database_host` not specified.
+
 ## [7.3.7] - 2024-09-10
 ### Fixed
 - Set `db_instance_class` default to `db.t4g.medium`.

--- a/db.tf
+++ b/db.tf
@@ -78,7 +78,7 @@ resource "aws_rds_cluster" "apiary_cluster" {
   final_snapshot_identifier           = "${local.instance_alias}-cluster-final-${random_id.snapshot_id[0].hex}"
   iam_database_authentication_enabled = true
   apply_immediately                   = var.db_apply_immediately
-  db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.apiary_rds_param_group.name
+  db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.apiary_rds_param_group[0].name
   storage_encrypted                   = var.encrypt_db
   copy_tags_to_snapshot               = var.db_copy_tags_to_snapshot
   lifecycle {

--- a/db.tf
+++ b/db.tf
@@ -47,6 +47,7 @@ resource "random_string" "db_master_password" {
 }
 
 resource "aws_rds_cluster_parameter_group" "apiary_rds_param_group" {
+  count       = var.external_database_host == "" ? 1 : 0
   name        = "${local.instance_alias}-param-group"
   family      = var.rds_family # Needs to be kept in sync with aws_rds_cluster.apiary_cluster.engine and version
   description = "Apiary-specific Aurora parameters"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description
### Fixed
- Enable `apiary_db_para_group` only when `external_database_host` not specified.

### :link: Related Issues