### PR TITLE
fix: correct MYSQL_DB_HOST in k8s readonly container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.3.9] - 2024-09-11
+### Fixed
+- Correct `MYSQL_DB_HOST` in readonly container.
+
 ## [7.3.8] - 2024-09-11
 ### Fixed
 - Enable `apiary_db_para_group` only when `external_database_host` not specified.

--- a/k8s-readonly.tf
+++ b/k8s-readonly.tf
@@ -70,7 +70,7 @@ resource "kubernetes_deployment_v1" "apiary_hms_readonly" {
 
             env {
               name  = "MYSQL_HOST"
-              value = var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.endpoint) : coalesce(var.external_database_host_readonly,var.external_database_host)
+              value = var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.endpoint) : try(var.external_database_host_readonly,var.external_database_host)
             }
 
             env {

--- a/k8s-readonly.tf
+++ b/k8s-readonly.tf
@@ -70,7 +70,7 @@ resource "kubernetes_deployment_v1" "apiary_hms_readonly" {
 
             env {
               name  = "MYSQL_HOST"
-              value = var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.endpoint) : try(var.external_database_host_readonly,var.external_database_host)
+              value = var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.endpoint) : var.external_database_host_readonly
             }
 
             env {

--- a/k8s-readonly.tf
+++ b/k8s-readonly.tf
@@ -70,7 +70,7 @@ resource "kubernetes_deployment_v1" "apiary_hms_readonly" {
 
             env {
               name  = "MYSQL_HOST"
-              value = var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.endpoint) : var.external_database_host_readonly
+              value = var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.endpoint) : var.external_database_host
             }
 
             env {
@@ -113,7 +113,7 @@ resource "kubernetes_deployment_v1" "apiary_hms_readonly" {
           }
           env {
             name  = "MYSQL_DB_HOST"
-            value = var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.reader_endpoint) : var.external_database_host
+            value = var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.reader_endpoint) : coalesce(var.external_database_host_readonly,var.external_database_host)
           }
           env {
             name  = "MYSQL_DB_NAME"

--- a/templates.tf
+++ b/templates.tf
@@ -75,7 +75,7 @@ locals{
   })
 
   hms_readonly_template = templatefile("${path.module}/templates/apiary-hms-readonly.json", {
-    mysql_db_host              = "${var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.reader_endpoint) : try(var.external_database_host_readonly,var.external_database_host)}"
+    mysql_db_host              = "${var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.reader_endpoint) : coalesce(var.external_database_host_readonly,var.external_database_host)}"
     mysql_db_name              = "${var.apiary_database_name}"
     mysql_secret_arn           = "${data.aws_secretsmanager_secret.db_ro_user.arn}"
     hive_metastore_access_mode = "readonly"

--- a/templates.tf
+++ b/templates.tf
@@ -75,7 +75,7 @@ locals{
   })
 
   hms_readonly_template = templatefile("${path.module}/templates/apiary-hms-readonly.json", {
-    mysql_db_host              = "${var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.reader_endpoint) : coalesce(var.external_database_host_readonly,var.external_database_host)}"
+    mysql_db_host              = "${var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.reader_endpoint) : try(var.external_database_host_readonly,var.external_database_host)}"
     mysql_db_name              = "${var.apiary_database_name}"
     mysql_secret_arn           = "${data.aws_secretsmanager_secret.db_ro_user.arn}"
     hive_metastore_access_mode = "readonly"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description

### Fixed
- Correct `MYSQL_DB_HOST` in readonly container
### :link: Related Issues