### PR TITLE
Merge S3 lifecycle configuration into one object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.9.2] - 2025-01-22
+### Fixed
+- Merged all S3 lifecycle configurations into `aws_s3_bucket_lifecycle_configuration` object.
+
 ## [7.9.1] - 2025-01-14
 ### Added
 - Added Splunk env for segrigatting logs for each environment.

--- a/s3.tf
+++ b/s3.tf
@@ -77,6 +77,7 @@ resource "aws_s3_bucket" "apiary_data_bucket" {
 resource "aws_s3_bucket_versioning" "apiary_data_bucket_versioning" {
   for_each = {
     for schema in local.schemas_info : "${schema["schema_name"]}" => schema
+    if lookup(schema, "s3_versioning_enabled", "") != ""
   }
   bucket = each.value["data_bucket"]
   versioning_configuration {

--- a/s3.tf
+++ b/s3.tf
@@ -87,6 +87,7 @@ resource "aws_s3_bucket_versioning" "apiary_data_bucket_versioning" {
 resource "aws_s3_bucket_lifecycle_configuration" "apiary_data_bucket_versioning_lifecycle" {
   for_each = {
     for schema in local.schemas_info : "${schema["schema_name"]}" => schema
+    if lookup(schema, "s3_versioning_enabled", "") != ""
   }
   bucket = each.value["data_bucket"]
   # Rule enabled when expiration max days is set

--- a/s3.tf
+++ b/s3.tf
@@ -55,6 +55,7 @@ resource "aws_s3_bucket" "apiary_data_bucket" {
 resource "aws_s3_bucket_versioning" "apiary_data_bucket_versioning" {
   for_each = {
     for schema in local.schemas_info : "${schema["schema_name"]}" => schema
+    if lookup(schema, "s3_versioning_enabled", "") != ""
   }
   bucket = each.value["data_bucket"]
   versioning_configuration {


### PR DESCRIPTION
`lifecycle_rule` is deprecated in terraform so this PR is to upgrade that configuration into `aws_s3_bucket_lifecycle_configuration`.

Also, there is a terraform warning which is:

> S3 Buckets only support a single lifecycle configuration. Declaring multiple aws_s3_bucket_lifecycle_configuration resources to the same S3 Bucket will cause a perpetual difference in configuration.

So I need to add all of them together and this PR is to merge them in one object.