### PR TITLE
Added abort_incomplete_multipart_upload rule into S3 lifecycle object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.9.4] - 2025-02-26
+### Fixed
+- Added `abort_incomplete_multipart_upload` rule into `aws_s3_bucket_lifecycle_configuration` object.
+
 ## [7.9.3] - 2025-02-25
 ### Fixed
 - Merged all S3 lifecycle configurations into `aws_s3_bucket_lifecycle_configuration` object.

--- a/s3.tf
+++ b/s3.tf
@@ -68,6 +68,15 @@ resource "aws_s3_bucket_lifecycle_configuration" "apiary_data_bucket_versioning_
     for schema in local.schemas_info : "${schema["schema_name"]}" => schema
   }
   bucket = each.value["data_bucket"]
+  # Rule for s3 incomplete multipart upload expiration
+  rule {
+    id     = "expire-incomplete-multipart-uploads"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = var.s3_lifecycle_abort_incomplete_multipart_upload_days
+    }
+  }
   # Rule for s3 versioning expiration
   rule {
     id     = "expire-noncurrent-versions-days"


### PR DESCRIPTION
Apiary-data-lake was using a deprecated s3 lifecycle terraform resource. In previous PRs, I updated to the new way versioning should be configured. However, I missed this part.