### PR TITLE
Add delete marker object expiration when s3 versioning is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.10.16] - 2025-05-29
+### Changed
+- Add delete marker object expiration when s3 versioning is enabled.
+
 ## [7.10.15] - 2025-05-23
 ### Changed
 - Fix outputs when gluedb creation is disabled.

--- a/s3.tf
+++ b/s3.tf
@@ -86,6 +86,15 @@ resource "aws_s3_bucket_lifecycle_configuration" "apiary_data_bucket_versioning_
       noncurrent_days = tonumber(lookup(each.value, "s3_versioning_expiration_days", var.s3_versioning_expiration_days))
     }
   }
+  # Rule s3 delete marker object expiration
+  rule {
+    id     = "expire-delete-marker"
+    status = lookup(each.value, "s3_versioning_enabled", "") != "" ? "Enabled" : "Disabled"
+
+    expiration {
+      expired_object_delete_marker = "true"
+    }
+  }
   # Rule s3 intelligent tiering transition
   rule {
     id     = "cost_optimization_transition"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description
Add delete marker object expiration when s3 versioning is enabled

### :link: Related Issues