### PR TITLE
optional variable to create lakeformation data acess role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.10.17] - 2025-05-30
+### Changed
+- Optional variable to create lakeformation data access role.
+
 ## [7.10.16] - 2025-05-29
 ### Changed
 - Add delete marker object expiration when s3 versioning is enabled.

--- a/variables.tf
+++ b/variables.tf
@@ -597,6 +597,12 @@ variable "create_lf_resource" {
   default     = false
 }
 
+variable "create_lf_data_access_role" {
+  description = "Create LakeFormation data access role."
+  type        = bool
+  default     = false
+}
+
 variable "lf_hybrid_access_enabled" {
   description = "Enable hybrid access for LakeFormation."
   type        = bool


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description
new variable to create lakeformation data access role, typically used when trying to add many s3 buckets to lakeformation data locations, to avoid reaching policy limits.

### :link: Related Issues